### PR TITLE
Add prometheus integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
-        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+        path: ~/.cabal/store
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: Running hlint

--- a/cabal.project
+++ b/cabal.project
@@ -12,3 +12,11 @@ source-repository-package
     type: git
     location: https://github.com/tchoutri/pg-entity.git
     tag: e5fc4cf
+
+source-repository-package
+    type: git
+    location: https://github.com/fimad/prometheus-haskell
+    tag: 43f19da
+    subdir: ./prometheus-metrics-ghc
+            ./prometheus-client 
+            ./wai-middleware-prometheus

--- a/deployment/flora.nginx
+++ b/deployment/flora.nginx
@@ -49,6 +49,10 @@ server {
     root /var/www/_letsencrypt;
   }
 
+  location /metrics {
+    deny all;
+  }
+
   location /static {
       root /var/www/xxxx/;
       etag off;

--- a/deployment/prometheus.yml
+++ b/deployment/prometheus.yml
@@ -1,0 +1,5 @@
+# Sample configuration to add to your own 'prometheus.yml'
+scrape_configs:
+  - job_name: flora-server
+    static_configs:
+      - targets: ['localhost:8003']

--- a/flora.cabal
+++ b/flora.cabal
@@ -51,7 +51,10 @@ common common-ghc-options
     -fhide-source-paths -Wno-unused-do-bind
 
 common common-rts-options
-  ghc-options: -rtsopts -threaded -with-rtsopts=-N
+  ghc-options:
+    -rtsopts
+    -threaded
+    -with-rtsopts "-N -T"
 
 library
   import:          common-extensions
@@ -83,46 +86,49 @@ library
     Lucid.Orphans
 
   build-depends:
-    , aeson                  ^>=1.5
-    , async                  ^>=2.2
-    , base                   ^>=4.14
+    , aeson                      ^>=1.5
+    , async                      ^>=2.2
+    , base                       ^>=4.14
     , blaze-builder
-    , bytestring             ^>=0.10
-    , Cabal                  ^>=3
-    , colourista             ^>=0.1
-    , containers             ^>=0.6
-    , cookie                 ^>=0.4
-    , cryptohash-sha256      ^>=0.11
-    , directory              ^>=1.3
-    , envparse               ^>=0.4
-    , hashable               ^>=1.3
-    , http-types             ^>=0.12
-    , lucid                  ^>=2.10
-    , lucid-alpine           ^>=0.1
-    , lucid-svg              ^>=0.7
-    , mtl                    ^>=2.2
-    , optics-core            ^>=0.4
-    , optparse-applicative   ^>=0.16
-    , password               ^>=3.0
-    , password-types         ^>=1.0
-    , pcre2                  ^>=2.0
-    , pg-entity              ^>=0.0
-    , pg-transact            ^>=0.3
-    , postgresql-simple      ^>=0.6
-    , pretty                 ^>=1.1
-    , resource-pool          ^>=0.2
-    , servant                ^>=0.18
-    , servant-lucid          ^>=0.9
-    , servant-server         ^>=0.18
-    , text                   ^>=1.2
+    , bytestring                 ^>=0.10
+    , Cabal                      ^>=3
+    , colourista                 ^>=0.1
+    , containers                 ^>=0.6
+    , cookie                     ^>=0.4
+    , cryptohash-sha256          ^>=0.11
+    , directory                  ^>=1.3
+    , envparse                   ^>=0.4
+    , hashable                   ^>=1.3
+    , http-types                 ^>=0.12
+    , lucid                      ^>=2.10
+    , lucid-alpine               ^>=0.1
+    , lucid-svg                  ^>=0.7
+    , mtl                        ^>=2.2
+    , optics-core                ^>=0.4
+    , optparse-applicative       ^>=0.16
+    , password                   ^>=3.0
+    , password-types             ^>=1.0
+    , pcre2                      ^>=2.0
+    , pg-entity                  ^>=0.0
+    , pg-transact                ^>=0.3
+    , postgresql-simple          ^>=0.6
+    , pretty                     ^>=1.1
+    , prometheus-client          ^>=1.1
+    , prometheus-metrics-ghc     ^>=1.0
+    , resource-pool              ^>=0.2
+    , servant                    ^>=0.18
+    , servant-lucid              ^>=0.9
+    , servant-server             ^>=0.18
+    , text                       ^>=1.2
     , text-display
-    , time                   ^>=1.9
-    , uuid                   ^>=1.3
-    , vector                 ^>=0.12
-    , wai                    ^>=3.2
-    , wai-cors               ^>=0.2
-    , wai-middleware-static  ^>=0.9
-    , warp                   ^>=3.3
+    , time                       ^>=1.9
+    , uuid                       ^>=1.3
+    , vector                     ^>=0.12
+    , wai                        ^>=3.2
+    , wai-cors                   ^>=0.2
+    , wai-middleware-prometheus  ^>=1.0
+    , wai-middleware-static      ^>=0.9
+    , warp                       ^>=3.3
 
 executable flora-server
   import:         common-extensions


### PR DESCRIPTION
## Proposed changes

This PR adds Prometheus integration, and additionally:

* Extends the `flora.nginx` file to protect the `/metrics` endpoint that is used
* Add a sample `prometheus.yml` file