### PR TITLE
Enable Sentry integration

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,3 +1,4 @@
+- ignore: {name: "Redundant ^."}
 - ignore: {name: "Eta reduce"}
 - ignore: {name: "Avoid lambda"}
 - ignore: {name: "Use newtype instead of data"}

--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,11 @@ tests: True
 
 source-repository-package
     type: git
+    location: https://github.com/supki/envparse
+    tag: de5944f
+
+source-repository-package
+    type: git
     location: https://github.com/tchoutri/pg-entity.git
     tag: e5fc4cf
 

--- a/environment.sh
+++ b/environment.sh
@@ -11,3 +11,6 @@ export PG_URI="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB
 export PG_CONNSTRING="host=${DB_HOST} dbname=${DB_DATABASE} user=${DB_USER} password=${DB_PASSWORD}"
 
 export FLORA_PORT=8083
+
+export FLORA_ENVIRONMENT="local"
+#export SENTRY_DSN="" # Set this variable in `environment.local.sh`, which is not tracked by git.

--- a/flora.cabal
+++ b/flora.cabal
@@ -70,6 +70,7 @@ library
     Flora.Model.Requirement
     Flora.Model.User
     Flora.Publish
+    Flora.Tracing
     FloraWeb.Server
     FloraWeb.Server.Auth
     FloraWeb.Server.Packages
@@ -95,7 +96,7 @@ library
     , cookie                     ^>=0.4
     , cryptohash-sha256          ^>=0.11
     , directory                  ^>=1.3
-    , envparse                   ^>=0.4
+    , envparse                   ^>=0.5
     , hashable                   ^>=1.3
     , http-types                 ^>=0.12
     , lucid                      ^>=2.10
@@ -113,6 +114,7 @@ library
     , pretty                     ^>=1.1
     , prometheus-client          ^>=1.1
     , prometheus-metrics-ghc     ^>=1.0
+    , raven-haskell              ^>=0.1
     , resource-pool              ^>=0.2
     , servant                    ^>=0.18
     , servant-lucid              ^>=0.9
@@ -124,6 +126,7 @@ library
     , vector                     ^>=0.12
     , wai                        ^>=3.2
     , wai-cors                   ^>=0.2
+    , wai-logger                 ^>=2.3
     , wai-middleware-heartbeat   ^>=0.0
     , wai-middleware-prometheus  ^>=1.0
     , wai-middleware-static      ^>=0.9

--- a/src/Flora/Tracing.hs
+++ b/src/Flora/Tracing.hs
@@ -1,0 +1,40 @@
+module Flora.Tracing where
+
+import Control.Exception (SomeException)
+import Data.ByteString.Char8 (unpack)
+import Flora.Environment
+import Network.Wai
+import Network.Wai.Handler.Warp
+import Optics.Core
+import System.Log.Raven (initRaven, register, silentFallback)
+import System.Log.Raven.Transport.HttpConduit (sendRecord)
+import System.Log.Raven.Types (SentryLevel (Error), SentryRecord (..))
+
+sentryOnException :: TracingEnv -> Maybe Request -> SomeException -> IO ()
+sentryOnException tracingEnv mRequest exception =
+  case tracingEnv ^. #sentryDSN of
+    Nothing -> pure ()
+    Just sentryDSN -> do
+      sentryService <- initRaven
+        sentryDSN
+        (\defaultRecord -> defaultRecord{srEnvironment = Just $ tracingEnv ^. #environment})
+        sendRecord
+        silentFallback
+      register
+        sentryService
+        "flora-logger"
+        Error
+        (formatMessage mRequest exception)
+        (recordUpdate mRequest exception)
+      defaultOnException mRequest exception
+
+formatMessage :: Maybe Request -> SomeException -> String
+formatMessage Nothing exception        = "Exception before request could be parsed: " ++ show exception
+formatMessage (Just request) exception = "Exception " ++ show exception ++ " while handling request " ++ show request
+
+recordUpdate :: Maybe Request -> SomeException -> SentryRecord -> SentryRecord
+recordUpdate Nothing _exception record        = record
+recordUpdate (Just request) _exception record = record
+  { srCulprit = Just $ unpack $ rawPathInfo request
+  , srServerName = unpack <$> requestHeaderHost request
+  }

--- a/src/FloraWeb/Server.hs
+++ b/src/FloraWeb/Server.hs
@@ -1,13 +1,17 @@
 module FloraWeb.Server where
 
 import Colourista.IO (blueMessage)
+import Control.Monad
 import Control.Monad.Reader (runReaderT)
+import Data.Maybe
 import qualified Data.Text as T
 import Network.Wai
 import Network.Wai.Handler.Warp
+import Network.Wai.Logger (withStdoutLogger)
 import Network.Wai.Middleware.Heartbeat (heartbeatMiddleware)
 import Network.Wai.Middleware.Prometheus (PrometheusSettings (..), prometheus)
-import Prometheus (register)
+import Optics.Operators
+import qualified Prometheus
 import Prometheus.Metric.GHC (ghcMetrics)
 import Servant
 import Servant.API.Generic
@@ -16,6 +20,7 @@ import Servant.Server.Generic
 
 import Flora.Environment
 import Flora.Model.User (User)
+import Flora.Tracing
 import FloraWeb.Server.Auth
 import qualified FloraWeb.Server.Pages as Pages
 import FloraWeb.Types
@@ -30,18 +35,22 @@ runFlora :: IO ()
 runFlora = do
   env <- getFloraEnv
   blueMessage $ "🌺 Starting Flora server on http://localhost:" <> T.pack (show $ httpPort env)
-  register ghcMetrics
+  when (isJust $ env ^. #tracing ^. #sentryDSN) (blueMessage "📋 Connected to Sentry endpoint")
+  Prometheus.register ghcMetrics
   runServer env
 
 runServer :: FloraEnv -> IO ()
-runServer floraEnv  = runSettings warpSettings $
-  promMiddleware
-  . heartbeatMiddleware
-  $ server
-  where
-    server = genericServeTWithContext (naturalTransform floraEnv) floraServer (genAuthServerContext floraEnv)
-    warpSettings = setPort (fromIntegral $ httpPort floraEnv ) defaultSettings
-    promMiddleware = prometheus $ PrometheusSettings ["metrics"] True True
+runServer floraEnv = withStdoutLogger $ \logger -> do
+  let server = genericServeTWithContext (naturalTransform floraEnv) floraServer (genAuthServerContext floraEnv)
+  let warpSettings = setPort (fromIntegral $ httpPort floraEnv ) $
+                     setLogger logger $
+                     setOnException (sentryOnException (floraEnv ^. #tracing))
+                     defaultSettings
+  let promMiddleware = prometheus $ PrometheusSettings ["metrics"] True True
+  runSettings warpSettings $
+    promMiddleware
+    . heartbeatMiddleware
+    $ server
 
 floraServer :: Routes (AsServerT FloraM)
 floraServer = Routes
@@ -55,3 +64,4 @@ naturalTransform env app =
 
 genAuthServerContext :: FloraEnv -> Context (AuthHandler Request User ': '[])
 genAuthServerContext floraEnv = authHandler floraEnv :. EmptyContext
+


### PR DESCRIPTION
## Proposed changes

This PR enables Sentry integration with [`raven-haskell`](https://hackage.haskell.org/package/raven-haskell). Two new environment variables are added:

* `$FLORA_ENVIRONMENT` that should be local, dev or prod
* `$SENTRY_DSN` that must be a valid Sentry DSN, cannot be null, but also if it doesn't exist, Sentry integration will be disabled.