### PR TITLE
Add category mapping and coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 <
 Session.vim
 _database/
+_data/
 deployments/prod.sh
 dist-newstyle
 environment.local.sh

--- a/app/cli/CoverageReport.hs
+++ b/app/cli/CoverageReport.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE ViewPatterns #-}
+module CoverageReport (runCoverageReport, CoverageReportOptions (..)) where
+
+import Flora.Model.Category
+
+import Colourista
+import Control.Monad
+import Data.Char
+import Data.Function
+import Data.List (groupBy, partition, sortOn)
+import Data.Ord
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.Display
+import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TL
+import Data.Traversable
+import Data.Version
+import Distribution.PackageDescription
+import Distribution.PackageDescription.Parsec
+import Distribution.Verbosity
+import Numeric
+import System.Console.ANSI
+import System.Directory
+import System.IO
+import System.Process.Typed
+import Text.ParserCombinators.ReadP
+
+data CoverageReportOptions = CoverageReportOptions
+  { forceDownload :: Bool
+  } deriving stock (Show, Eq)
+
+fetchCategories :: CoverageReportOptions -> IO [[Text]]
+fetchCategories CoverageReportOptions{..} = do
+  workdir <- (<> "/_data/package-index") <$> getCurrentDirectory
+
+  when forceDownload $ do
+    removeDirectoryRecursive workdir
+
+  createDirectoryIfMissing True workdir
+  setCurrentDirectory workdir
+
+  indexExists <- doesFileExist "01-index.tar.gz"
+  if indexExists
+    then skipMessage " Package index already exists"
+    else void $ do
+    T.putStrLn ":: Fetching the package index from Hackage..."
+    runProcess $ proc "curl" ["-O", "https://hackage.haskell.org/01-index.tar.gz"]
+    T.putStrLn ":: Extracting the package index..."
+    runProcess $ proc "tar" ["xf", workdir <> "/01-index.tar.gz"]
+
+  T.putStrLn ":: Searching the package index..."
+  (_code, latestVersions . T.lines . TL.toStrict . TL.decodeUtf8 -> out) <-
+    readProcessStdout $ proc "find" [".", "-name", "*.cabal"]
+
+  T.putStrLn ":: Parsing the package index..."
+  let total = length out
+  catStrings <- for (zip [0 :: Int ..] . latestVersions $ out) $ \(i, path) -> do
+    clearLine
+    T.putStr $ "\r[" <> display i <> "/" <> display total <> "] Parsing " <>  T.take 120 (T.drop 2 path)
+    hFlush stdout
+    T.pack . category . packageDescription <$> readGenericPackageDescription silent (T.unpack path)
+
+  clearLine
+
+  pure $ map categorySplit catStrings
+
+data Coverage = Coverage
+  { numPackages      :: Int
+  , numMatched       :: Int
+  , numUncategorized :: Int
+  , numDropped       :: Int
+  , numOther         :: Int
+  }
+
+coverage :: [[Text]] -> Coverage
+coverage pkgs = Coverage
+  { numPackages = length pkgs
+  , numMatched = length matched
+  , numDropped = length dropped
+  , numUncategorized = length uncategorized
+  , numOther = length notdropped
+  }
+  where
+    (matched, unmatched) = partition (any (hasMapping . lookupCategory)) pkgs
+    (uncategorized, categorized) = partition null unmatched
+    (dropped, notdropped) = partition (all (isDropped . lookupCategory)) categorized
+
+    hasMapping (Just (_:_,_)) = True
+    hasMapping _              = False
+
+    isDropped (Just ([],_)) = True
+    isDropped _             = False
+
+categorySplit :: Text -> [Text]
+categorySplit xs | T.all isSpace xs = []
+categorySplit xs = if last res == "" then init res else res
+  where
+    res = map (T.dropWhile isSpace) $ T.splitOn "," xs
+
+runCoverageReport :: CoverageReportOptions -> IO ()
+runCoverageReport opts = do
+  blueMessage "\nInitiating a Hackage category coverage report."
+  cats <- fetchCategories opts
+  let Coverage {..} = coverage cats
+      toPercentage x = fromIntegral x * 100 / fromIntegral numPackages :: Double
+      percent x = "(" <> T.pack (showFFloat (Just 1) (toPercentage x) "%)")
+      line x = display x <> " " <> percent x <> "\n"
+  greenMessage $ T.concat
+    [ "\n============== Coverage Report ==============\n"
+    , "Total: ", display numPackages, "\n"
+    , "Successfully mapped to at least one category: ", line numMatched
+    , "Has no category: ", line numUncategorized
+    , "All categories are dropped: ", line numDropped
+    , "Other: ", line numOther
+    , "=============================================\n"
+    ]
+
+latestVersions :: [Text] -> [Text]
+latestVersions = concatMap (take 1 . sortOn secondPart) . groupBy ((==) `on` firstPart)
+  where
+    firstPart = T.takeWhile (/= '/') . T.drop 2 -- Keep only the package name
+    secondPart
+      = Down . map fst . readP_to_S (parseVersion <* eof) . T.unpack
+      . T.takeWhile (/= '/') . T.drop 1 . T.dropWhile (/= '/') . T.drop 2 -- Drop the package name

--- a/app/cli/Main.hs
+++ b/app/cli/Main.hs
@@ -9,12 +9,15 @@ import Flora.PackageFixtures
 import Flora.Publish
 import Flora.UserFixtures
 
+import CoverageReport
+
 data Options = Options
   { cliCommand :: Command
   } deriving stock (Show, Eq)
 
 data Command
   = Provision
+  | CoverageReport CoverageReportOptions
   deriving stock (Show, Eq)
 
 main :: IO ()
@@ -26,10 +29,15 @@ parseOptions =
 
 parseCommand :: Parser Command
 parseCommand = subparser $
-  command "provision-fixtures" (parseProvision `withInfo` "Load the fixtures into the database")
+     command "provision-fixtures" (parseProvision `withInfo` "Load the fixtures into the database")
+  <> command "coverage-report" (parseCoverageReport `withInfo` "Run a coverage report of the category mapping")
 
 parseProvision :: Parser Command
 parseProvision = pure Provision
+
+parseCoverageReport :: Parser Command
+parseCoverageReport = CoverageReport . CoverageReportOptions
+  <$> switch ( long "force-download" <> help "Always download and extract the package index" )
 
 runOptions :: Options -> IO ()
 runOptions (Options Provision) = do
@@ -50,6 +58,7 @@ runOptions (Options Provision) = do
     publishPackage [integerGmpDepOnGhcPrim] integerGmpRelease integerGmp user1
     publishPackage [bytestringDepOnBase, bytestringDepOnDeepseq, bytestringDepOnGhcBignum, bytestringDepOnGhcPrim, bytestringDepOnIntegerGmp] bytestringRelease bytestring syl20
     publishPackage [binaryDepOnArray, binaryDepOnBase, binaryDepOnBytestring, binaryDepOnContainers, binaryDepOnGhcPrim] binaryRelease binary user2
+runOptions (Options (CoverageReport opts)) = runCoverageReport opts
 
 withInfo :: Parser a -> String -> ParserInfo a
 withInfo opts desc = info (helper <*> opts) $ progDesc desc

--- a/flora.cabal
+++ b/flora.cabal
@@ -32,6 +32,7 @@ common common-extensions
     GeneralizedNewtypeDeriving
     InstanceSigs
     KindSignatures
+    LambdaCase
     MultiParamTypeClasses
     NamedFieldPuns
     OverloadedLabels
@@ -43,6 +44,7 @@ common common-extensions
     StrictData
     TypeApplications
     TypeOperators
+    ViewPatterns
 
   default-language:   Haskell2010
 
@@ -62,6 +64,7 @@ library
   exposed-modules:
     Data.Aeson.Orphans
     Flora.Environment
+    Flora.Model.Category
     Flora.Model.Organisation
     Flora.Model.Package
     Flora.Model.Package.Orphans
@@ -153,10 +156,14 @@ executable flora-cli
   import:         common-ghc-options
   import:         common-rts-options
   main-is:        Main.hs
+  other-modules:  CoverageReport
   hs-source-dirs: app/cli
   build-depends:
+    , ansi-terminal
     , base
+    , Cabal
     , colourista
+    , directory
     , flora
     , flora-test-fixtures
     , optparse-applicative         ^>=0.16
@@ -165,6 +172,8 @@ executable flora-cli
     , postgresql-simple
     , postgresql-simple-migration
     , text
+    , text-display
+    , typed-process
     , uuid
 
 library flora-test-fixtures

--- a/src/Flora/Model/Category.hs
+++ b/src/Flora/Model/Category.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE LambdaCase #-}
+module Flora.Model.Category
+  (  -- * Slugs
+    Slug
+  , fromSlug
+  , mkSlug
+  , coerceSlug
+  , CategoryS
+  , TagS
+    -- * Category lookups
+  , lookupCategory
+  , lookupCategories
+  ) where
+
+import Data.Bifunctor
+import Data.Char
+import Data.Coerce
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.String
+import Data.Text (Text)
+import qualified Data.Text as T
+
+-- | A slug type for category slugs.
+data CategoryS
+
+-- | A slug type for tag slugs.
+data TagS
+
+newtype Slug ty = Slug Text
+  deriving stock (Eq, Show, Ord)
+  deriving newtype (IsString)
+
+-- | Convert a 'Slug' to 'Text'.
+fromSlug :: Slug ty -> Text
+fromSlug (Slug txt) = txt
+
+-- | Create a 'Slug'.
+mkSlug :: Text -> Slug ty
+mkSlug = Slug
+
+-- | Manually convert between different types of `Slug`s.
+coerceSlug :: Slug ty1 -> Slug ty2
+coerceSlug = coerce
+
+catMapping :: Map Text ([Slug CategoryS], [Slug TagS])
+catMapping = Map.fromList
+  [ forget "data"
+  , keep "web"
+  , keep "network"
+  , keep "text"
+  , keep "development"
+  , forget "control"
+  , keep "system"
+  , "language" .= only "compilers"
+  , keep "math"
+  , keep "graphics"
+  , "database" .= only"database"
+  , keep "testing"
+  , keep "cloud"
+  , keep "data-structures"
+  , "game" .= only "game-dev"
+  , "parsing" .= only "parsers"
+  , keep "concurrency"
+  , "sound" .= only"sound"
+  , "distributed-computing" .= only "distributed"
+  , "google" .= ([], ["google"])
+  , "codec" .= only "codecs"
+  , "aws" .= (["cloud"], ["aws"])
+  , keep "cryptography"
+  , "distribution" .= only "packaging"
+  , "compilers-interpreters" .= only "compilers"
+  , keep "ffi"
+  , keep "bioinformatics"
+  , keep "algorithms"
+  , keep "generics"
+  , keep "xml"
+  , "foreign" .= only "ffi"
+  , keep "json"
+  , "yesod" .= (["web"], ["yesod"])
+  , keep "music"
+  , keep "frp"
+  , keep "utils"
+  , keep "console"
+  , keep "natural-language-processing"
+  , keep "monads"
+  , keep "prelude"
+  , keep "user-interfaces"
+  , keep "ai"
+  , keep "gui"
+  , "conduit" .= (["streaming"], ["conduit"])
+  , keep "finance"
+  , "compiler" .= only "compilers"
+  , keep "numeric"
+  , "numerical" .= only "numeric"
+  ]
+  where
+    only a = ([a], [])
+    keep slug = slug .= only (Slug slug)
+    forget slug = slug .= ([], [])
+    ( .=) = (,)
+
+normalizeHackageCategory :: Text -> Text
+normalizeHackageCategory = T.concatMap $ \case
+  '/'                 -> "-"
+  ' '                 -> "-"
+  c | not (isAlpha c) -> ""
+    | otherwise -> T.singleton $ toLower c
+
+-- | Look up a Hackage category in the mapping, normalizing it first.
+lookupCategory :: Text -> Maybe ([Slug CategoryS], [Slug TagS])
+lookupCategory cat = Map.lookup (normalizeHackageCategory cat) catMapping
+
+-- | Look up a collection of Hackage categories in the mapping and return all the
+-- mapped categories and tags.
+lookupCategories :: [Text] -> ([Slug CategoryS], [Slug TagS])
+lookupCategories cats = bimap concat concat . unzip $ mapMaybe lookupCategory cats


### PR DESCRIPTION
## Proposed changes

Adds a `Map` that serves to map the most common Hackage categories to canonical Flora category slugs and tags. Also includes a cli utility for downloading the package index and checking what coverage the mapping provides across all of Hackage.

## Contributor checklist

- [x] My PR is related to #26 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
