### PR TITLE
Change nix-shell to seperate package resolution with overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,24 @@
 name: CI
 
-# Trigger the workflow on push or pull request, but only for the main branch
 on:
   pull_request:
   push:
-    branches: ['main', 'development']
-
 jobs:
-  cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        cabal: ['3.4.0.0']
-        ghc: ['8.10.7']
-
+  tests:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
-
-    - uses: haskell/actions/setup@v1
-      id: setup-haskell-cabal
-      name: Setup Haskell
+    - uses: actions/checkout@v2.3.1
+    - uses: cachix/install-nix-action@v12
       with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
-
+        nix_path: nixpkgs=channel:nixos-unstable
+    # - uses: cachix/cachix-action@v6
+    #   with:
+    #     name: jappie
+    #     signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    #     # Only needed for private caches
+    #     #authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix-build nix/ci.nix
+    - run: nix-shell --run "echo OK"
     - name: Configure environment
       run: |
         echo '/usr/lib/postgresql/12/bin/' >> $GITHUB_PATH
@@ -36,36 +28,11 @@ jobs:
         echo '$HOME/.ghcup/bin' >> $GITHUB_PATH
         echo 'HOME/.cabal/bin' >> $GITHUB_PATH
         echo 'HOME/.local/bin' >> $GITHUB_PATH
-
-    - name: Install Nix
-      run: |
-        cd .github/workflows
-        ./install-nix.sh
-
-    - name: Configure
-      run: |
-        cabal configure --enable-tests --test-show-details=direct
-
-    - name: Freeze
-      run: |
-        nix-shell --run 'cabal freeze'
-
-    - uses: actions/cache@v2
-      name: Cache ~/.cabal/store
-      with:
-        path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-
     - name: Running hlint
       run: nix-shell --run './.github/workflows/hlint-runner.sh'
 
     - name: Running stylish-haskell
       run: nix-shell --run './.github/workflows/stylish-haskell-runner.sh'
-
-    - name: Build
-      run: |
-        nix-shell --run 'make build'
-
     - name: Test
       run: |
         nix-shell --run 'make test'

--- a/cabal.project
+++ b/cabal.project
@@ -23,13 +23,5 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/fimad/prometheus-haskell
-    tag: 43f19da
-    subdir: ./prometheus-metrics-ghc
-            ./prometheus-client 
-            ./wai-middleware-prometheus
-
-source-repository-package
-    type: git
     location: https://github.com/flora-pm/wai-middleware-heartbeat
     tag: bd7dbbe

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import ./nix/pkgs.nix,
+  # should be default ghc
+  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix#L9029
+  ... }:
+
+let
+  hpkgs = pkgs.haskellPackages;
+  ignore = import ./nix/gitignoreSource.nix { inherit (pkgs) lib; };
+  # https://github.com/NixOS/nixpkgs/blob/dbacb52ad8/pkgs/development/haskell-modules/make-package-set.nix#L216
+  src = ignore.gitignoreSource ./.;
+  cabal2nix =
+    hpkgs.callCabal2nix "flora-server" src {
+    };
+in
+# https://github.com/NixOS/nixpkgs/blob/dbacb52ad8/pkgs/development/haskell-modules/generic-builder.nix#L13
+
+pkgs.haskell.lib.overrideCabal cabal2nix (drv: {
+  inherit src;
+  isExecutable = true;
+})

--- a/flora.cabal
+++ b/flora.cabal
@@ -92,7 +92,7 @@ library
     , base                       ^>=4.14
     , blaze-builder
     , bytestring                 ^>=0.10
-    , Cabal                      ^>=3
+    , Cabal                      
     , clock                      ^>=0.8
     , cmark-gfm                  ^>=0.2
     , colourista                 ^>=0.1
@@ -103,27 +103,27 @@ library
     , envparse                   ^>=0.5
     , hashable                   ^>=1.3
     , http-types                 ^>=0.12
-    , lucid                      ^>=2.10
+    , lucid                      
     , lucid-alpine               ^>=0.1
     , lucid-svg                  ^>=0.7
     , mtl                        ^>=2.2
-    , optics-core                ^>=0.4
+    , optics-core                
     , optparse-applicative       ^>=0.16
     , password                   ^>=3.0
     , password-types             ^>=1.0
-    , pcre2                      ^>=2.0
+    , pcre2                      
     , pg-entity                  ^>=0.0
     , pg-transact                ^>=0.3
     , postgresql-simple          ^>=0.6
     , pretty                     ^>=1.1
-    , prometheus-client          ^>=1.1
-    , prometheus-metrics-ghc     ^>=1.0
-    , prometheus-proc            ^>=0.1
-    , PyF                        ^>=0.10
+    , prometheus-client          
+    , prometheus-metrics-ghc     
+    , prometheus-proc            
+    , PyF                        
     , raven-haskell              ^>=0.1
     , resource-pool              ^>=0.2
     , servant                    ^>=0.18
-    , servant-lucid              ^>=0.9
+    , servant-lucid              
     , servant-server             ^>=0.18
     , text                       ^>=1.2
     , text-display
@@ -134,7 +134,7 @@ library
     , wai-cors                   ^>=0.2
     , wai-logger                 ^>=2.3
     , wai-middleware-heartbeat   ^>=0.0
-    , wai-middleware-prometheus  ^>=1.0
+    , wai-middleware-prometheus  
     , wai-middleware-static      ^>=0.9
     , warp                       ^>=3.3
 

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,0 +1,7 @@
+{
+  default = import ../default.nix {};
+  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/haskell-packages.nix#L47
+  shell = (import ../shell.nix {});
+
+
+}

--- a/nix/gitignoreSource.nix
+++ b/nix/gitignoreSource.nix
@@ -1,0 +1,9 @@
+let
+  owner = "hercules-ci";
+  repo = "gitignore";
+  rev = "c4662e662462e7bf3c2a968483478a665d00e717";
+in
+  import (builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = "sha256:1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
+  })

--- a/nix/pin.nix
+++ b/nix/pin.nix
@@ -1,0 +1,4 @@
+import (builtins.fetchTarball {
+      # master on 2021-11-07
+      url = "https://github.com/NixOS/nixpkgs/archive/2c2a09678ce2ce4125591ac4fe2f7dfaec7a609c.tar.gz";
+    })

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,34 @@
+import ./pin.nix {
+  config = {
+
+    packageOverrides = pkgs: {
+        haskell = pkgs.lib.recursiveUpdate pkgs.haskell {
+          packageOverrides = hpNew: hpOld:
+            let
+            sourcePrometheus = fetchTarball {
+                url = "https://github.com/fimad/prometheus-haskell/archive/43f19da.tar.gz";
+                sha256 = "1xg3jyhy60xxhcwcl8sc55r7yzya0nqjl8bchms6cvfnzldrcih5";
+            };
+            in
+            {
+            flora-server = hpNew.callPackage ../default.nix {};
+            wai-middleware-heartbeat = hpNew.callCabal2nix "wai-middleware-heartbeat" (fetchTarball {
+                url = "https://github.com/flora-pm/wai-middleware-heartbeat/archive/bd7dbbe.tar.gz";
+                sha256 = "1s2flv2jhfnd4vdfg6rmvq7s852w1pypasdg0l6ih6raaqyqzybn";
+            }) {};
+            pg-transact = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.unmarkBroken hpOld.pg-transact);
+            hspec-pg-transact = pkgs.haskell.lib.dontCheck (hpOld.hspec-pg-transact);
+            postgresql-migration = pkgs.haskell.lib.unmarkBroken hpOld.postgresql-migration;
+            text-display = pkgs.haskell.lib.unmarkBroken hpOld.text-display;
+            pg-entity = pkgs.haskell.lib.dontCheck hpOld.pg-entity;
+
+            servant-lucid = hpOld.callHackage "servant-lucid" "0.9.0.3" {};
+            envparse = hpNew.callCabal2nix "envparse" (fetchTarball {
+                url = "https://github.com/supki/envparse/archive/de5944f.tar.gz";
+                sha256 = "0piljyzplj3bjylnxqfl4zpc3vc88i9fjhsj06bk7xj48dv3jg3b";
+            }) {};
+            };
+        };
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,37 +1,29 @@
-let pkgs = import (builtins.fetchTarball {
-      # master on 2021-11-07
-      url = "https://github.com/NixOS/nixpkgs/archive/2c2a09678ce2ce4125591ac4fe2f7dfaec7a609c.tar.gz";
-    }) { };
-in with pkgs;
-  mkShell rec {
-    shellHook = ''
-      source environment.sh
-      export LOCALE_ARCHIVE="/nix/store/m53mq2077pfxhqf37gdbj7fkkdc1c8hc-glibc-locales-2.27/lib/locale/locale-archive"
-      export LC_ALL=C.UTF-8
-      export LD_LIBRARY_PATH="${lib.makeLibraryPath buildInputs}";
-    '';
-    buildInputs = [
-      # Haskell Deps
-      haskell.compiler.ghc8107
-      cabal-install
-      ghcid
-      hlint
-      cacert
-      haskellPackages.apply-refact
-      stylish-haskell
-      git
-      haskellPackages.cabal-fmt
+{
+  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/haskell-packages.nix
+  pkgs ? import ./nix/pkgs.nix
+}:
+#  https://input-output-hk.github.io/haskell.nix/tutorials/development/
+pkgs.haskellPackages.shellFor {
+  packages = ps : [ ps.flora-server ];
+  buildInputs = [
+        pkgs.ghcid
+        pkgs.cabal-install
+        pkgs.hlint
+        pkgs.cacert
+        pkgs.haskellPackages.apply-refact
+        pkgs.stylish-haskell
+        pkgs.git
+        pkgs.haskellPackages.cabal-fmt
 
-      # DB Deps
-      postgresql_14
-      gmp
-      zlib
-      glibcLocales
-      haskellPackages.postgresql-simple-migration
-
-      # Extra
-      direnv
-      yarn
-      nodejs
-    ];
-  }
+        pkgs.direnv
+        pkgs.yarn
+        pkgs.nodejs
+        ];
+  exactDeps = true;
+  NIX_PATH="nixpkgs=${pkgs.path}:.";
+  shellHook = ''
+    source environment.sh
+    export LOCALE_ARCHIVE="/nix/store/m53mq2077pfxhqf37gdbj7fkkdc1c8hc-glibc-locales-2.27/lib/locale/locale-archive"
+    export LC_ALL=C.UTF-8
+  '';
+}


### PR DESCRIPTION
## Proposed changes

This will make cabal use nix-cache for depenencies,
I was not sure if that was happening before.
Overrides are easier done with hpOld/hpNew

Cabal isn't supposed to build libraries,
it should only build the project you're working on.
The nix cache is used for all dependencies.

Furthermore this should allow us to create a ci.nix
file which does all the steps and then only thing gh
actions will do is call nix-build ci.nix.
The main advantage of this is that you now can
run (and debug) CI locally.

In short:

+ make cabal cache dependencies
+ move package resolution out of ci
+ hook ci straight into the nix build
+ add a default.nix.


## Contributor checklist

- [ ] My PR is related to \<insert ticket number>  (sorry I decided to do this on a whim when I saw the nix stuff, close if this isn't considered helpfull)
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md) (it's an ops change).
