### PR TITLE
Remove the usage of a Map to store template variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: Install Nix
       run: |
+        ls -ah
         cd .github/workflows
         ./install-nix.sh
 

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ in with pkgs;
       stylish-haskell
       git
       haskellPackages.cabal-fmt
+      ncurses6
 
       # DB Deps
       postgresql_14

--- a/src/FloraWeb/Server/Pages.hs
+++ b/src/FloraWeb/Server/Pages.hs
@@ -7,7 +7,6 @@ import Servant.API.Generic
 import Servant.HTML.Lucid
 import Servant.Server.Generic
 
-import qualified Data.Map.Strict as Map
 import Flora.Environment
 import FloraWeb.Server.Auth
 import qualified FloraWeb.Server.Pages.Packages as Packages
@@ -45,13 +44,12 @@ ensureUser adminM = do
 
 homeHandler :: FloraPageM (Html ())
 homeHandler = do
-  let assigns = mkAssigns emptyAssigns (Just (UserAssigns $ Map.fromList [("navbar-search", "false")]))
-  render assigns Home.show
+  let templateEnv = defaultTemplateEnv{displayNavbarSearch = False}
+  render templateEnv Home.show
 
 aboutHandler :: FloraPageM (Html ())
 aboutHandler = do
-  let assigns = emptyAssigns
-  render assigns Home.about
+  render defaultTemplateEnv Home.about
 
 adminHandler :: FloraAdminM (Html ())
 adminHandler = undefined

--- a/src/FloraWeb/Server/Pages/Packages.hs
+++ b/src/FloraWeb/Server/Pages/Packages.hs
@@ -61,7 +61,7 @@ showHandler namespaceText nameText = do
           releases <- liftIO $ withPool pool $ getReleases (package ^. #packageId)
           let latestRelease =  maximumBy (compare `on` version) releases
           latestReleasedependencies <- liftIO $ withPool pool $ getRequirements (latestRelease ^. #releaseId)
-          render emptyAssigns $ Packages.showPackage latestRelease package dependents latestReleasedependencies
+          render defaultTemplateEnv $ Packages.showPackage latestRelease package dependents latestReleasedependencies
     _ -> renderError notFound404
 
 showVersionHandler :: Text -> Text -> Text -> FloraPageM (Html ())
@@ -79,7 +79,7 @@ showVersionHandler namespaceText nameText versionText = do
               Nothing -> renderError notFound404
               Just release -> do
                 releaseDependencies <- liftIO $ withPool pool $ getRequirements (release ^. #releaseId)
-                render emptyAssigns $ Packages.showPackage release package dependents releaseDependencies
+                render defaultTemplateEnv $ Packages.showPackage release package dependents releaseDependencies
     _ -> renderError notFound404
 
 

--- a/src/FloraWeb/Templates.hs
+++ b/src/FloraWeb/Templates.hs
@@ -9,13 +9,13 @@ import FloraWeb.Server.Auth
 import FloraWeb.Templates.Layout.App (footer, header)
 import FloraWeb.Templates.Types
 
-render :: TemplateAssigns -> FloraHTML -> FloraPageM (Html ())
-render ta template = pure $ toHtmlRaw $ runIdentity $
-  runReaderT (renderBST (rendered template)) ta
+render :: TemplateEnv -> FloraHTML -> FloraPageM (Html ())
+render env template = pure $ toHtmlRaw $ runIdentity $
+  runReaderT (renderBST (rendered template)) env
 
-mkErrorPage :: TemplateAssigns -> FloraHTML -> ByteString
-mkErrorPage ta template = runIdentity $
-  runReaderT (renderBST (rendered template)) ta
+mkErrorPage :: TemplateEnv -> FloraHTML -> ByteString
+mkErrorPage env template = runIdentity $
+  runReaderT (renderBST (rendered template)) env
 
 rendered :: FloraHTML -> FloraHTML
 rendered target = do

--- a/src/FloraWeb/Templates/Error.hs
+++ b/src/FloraWeb/Templates/Error.hs
@@ -3,7 +3,6 @@ module FloraWeb.Templates.Error
   , showError
   ) where
 
-import qualified Data.Map.Strict as Map
 import Lucid
 import Network.HTTP.Types.Status
 
@@ -14,8 +13,8 @@ import Servant
 
 renderError :: Status -> FloraPageM a
 renderError status = do
-  let assigns = TemplateAssigns (Map.singleton "display-title" "Flora :: *** Exception" )
-  let body = mkErrorPage assigns $ showError status
+  let templateEnv =  defaultTemplateEnv{title = "Flora :: *** Exception"}
+  let body = mkErrorPage templateEnv $ showError status
   throwError $ ServerError{ errHTTPCode = statusCode status
                      , errBody = body
                      , errReasonPhrase = ""

--- a/src/FloraWeb/Templates/Layout/App.hs
+++ b/src/FloraWeb/Templates/Layout/App.hs
@@ -11,13 +11,13 @@ import PyF
 
 header :: FloraHTML
 header = do
-  assigns <- ask
+  TemplateEnv{title} <- ask
   doctype_
   html_ [lang_ "en", class_ "no-js dark"] $ do
     head_ $ do
       meta_ [charset_ "UTF-8"]
       meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
-      title_ (text $ getTitle assigns)
+      title_ (text title)
 
       script_ [type_ "module"] $ do
         toHtmlRaw @Text [fmt|
@@ -40,7 +40,7 @@ header = do
       theme
       link_ [rel_ "icon", href_ "/favicon.ico"]
       link_ [rel_ "icon", href_ "/favicon.svg", type_ "image/svg+xml"]
-      link_ [rel_ "canonical", href_ $ getCanonicalURL assigns]
+      -- link_ [rel_ "canonical", href_ $ getCanonicalURL assigns]
       meta_ [name_ "twitter:dnt", content_ "on"]
 
     body_ [class_ "bg-background dark:bg-background-dark dark:text-gray-100"]$ do
@@ -68,12 +68,12 @@ footer =
 
 ogTags :: FloraHTML
 ogTags = do
-      assigns <- ask
-      meta_ [property_ "og:title", content_ (getTitle assigns)]
-      meta_ [property_ "og:site_name", content_ "Hex"]
-      meta_ [property_ "og:description", content_ (getDescription assigns) ]
-      meta_ [property_ "og:url", content_ (getCanonicalURL assigns)]
-      meta_ [property_ "og:image", content_ (getImage assigns)]
+      TemplateEnv{title, description} <- ask
+      meta_ [property_ "og:title", content_ title]
+      meta_ [property_ "og:site_name", content_ "Flora"]
+      meta_ [property_ "og:description", content_ description ]
+      -- meta_ [property_ "og:url", content_ (getCanonicalURL assigns)]
+      -- meta_ [property_ "og:image", content_ (getImage assigns)]
       meta_ [property_ "og:image:width",  content_ "160"]
       meta_ [property_ "og:image:height", content_ "160"]
       meta_ [property_ "og:locale", content_ "en_GB"]
@@ -86,12 +86,12 @@ theme = do
 
 navBar :: FloraHTML
 navBar = do
-  ta <- ask
+  TemplateEnv{title} <- ask
   nav_ [class_ "border-b dark:border-transparent bg-gray-200 dark:bg-background-dark"] $ do
     div_ [class_ "max-w-9xl mx-auto px-4 sm:px-6 lg:px-8"] $ do
       div_ [class_ "flex justify-between h-16"] $ do
         div_ [class_ "flex-shrink-0 flex items-center"] $ do
-          a_ [href_ "/", class_ "flex-shrink-0 py-2 border-b border-b-2 border-b-brand-purple inline-flex items-center px-1 pt-1 mx-7 font-bold text-black dark:text-gray-100"] (getDisplayTitle ta)
+          a_ [href_ "/", class_ "flex-shrink-0 py-2 border-b border-b-2 border-b-brand-purple inline-flex items-center px-1 pt-1 mx-7 font-bold text-black dark:text-gray-100"] (text title)
           navbarSearch
 
         let elementClass = "navbar-element py-2 border-b border-b-brand-purple inline-flex items-center px-1 pt-1 border-b-2 mx-7 text-black dark:text-gray-100"
@@ -103,7 +103,7 @@ navBar = do
 
 navbarSearch :: FloraHTML
 navbarSearch = do
-  flag <- asks getNavbarSearchFlag
+  flag <- asks displayNavbarSearch
   if flag
   then do
     form_ [class_ "w-full max-w-sm ml-5", action_ "#"] $ do
@@ -131,24 +131,3 @@ property_ = makeAttribute "property"
 
 text :: Text -> FloraHTML
 text = toHtml
-
-getTitle :: TemplateAssigns -> Text
-getTitle ta = getTA ta "Flora" "title"
-
-getNavbarSearchFlag :: TemplateAssigns -> Bool
-getNavbarSearchFlag ta =
-  case getTA ta "true" "navbar-search" of
-    "true" -> True
-    _      -> False
-
-getDisplayTitle :: TemplateAssigns -> FloraHTML
-getDisplayTitle ta = toHtml $ getTA ta "Flora :: [Package]" "display-title"
-
-getDescription :: TemplateAssigns -> Text
-getDescription ta = getTA ta "A package repository for the Haskell ecosystem" "description"
-
-getCanonicalURL :: TemplateAssigns -> Text
-getCanonicalURL ta = getTA ta "" "canonical_url"
-
-getImage :: TemplateAssigns -> Text
-getImage ta = getTA ta "" "image"

--- a/src/FloraWeb/Templates/Types.hs
+++ b/src/FloraWeb/Templates/Types.hs
@@ -2,9 +2,9 @@ module FloraWeb.Templates.Types where
 
 import Control.Monad.Identity
 import Control.Monad.Reader
-import Lucid
-import GHC.Generics
 import Data.Text (Text)
+import GHC.Generics
+import Lucid
 
 type FloraHTML = HtmlT (ReaderT TemplateEnv Identity) ()
 
@@ -15,10 +15,10 @@ newtype FlashError = FlashError { getFlashInfo :: Text }
 
 data TemplateEnv = TemplateEnv
   { displayNavbarSearch :: Bool
-  , flashInfo :: Maybe FlashInfo
-  , flashError ::Maybe FlashError
-  , title :: Text
-  , description :: Text
+  , flashInfo           :: Maybe FlashInfo
+  , flashError          ::Maybe FlashError
+  , title               :: Text
+  , description         :: Text
   }
   deriving stock (Show, Generic)
 

--- a/src/FloraWeb/Templates/Types.hs
+++ b/src/FloraWeb/Templates/Types.hs
@@ -2,31 +2,31 @@ module FloraWeb.Templates.Types where
 
 import Control.Monad.Identity
 import Control.Monad.Reader
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import Data.Text
 import Lucid
+import GHC.Generics
+import Data.Text (Text)
 
-type TemplateEnv = ReaderT TemplateAssigns Identity
+type FloraHTML = HtmlT (ReaderT TemplateEnv Identity) ()
 
-type FloraHTML = HtmlT TemplateEnv ()
+newtype FlashInfo = FlashInfo { getFlashInfo :: Text }
+  deriving Show via Text
+newtype FlashError = FlashError { getFlashInfo :: Text }
+  deriving Show via Text
 
-newtype TemplateAssigns = TemplateAssigns { getAssigns :: Map Text Text }
-  deriving newtype (Show, Eq)
+data TemplateEnv = TemplateEnv
+  { displayNavbarSearch :: Bool
+  , flashInfo :: Maybe FlashInfo
+  , flashError ::Maybe FlashError
+  , title :: Text
+  , description :: Text
+  }
+  deriving stock (Show, Generic)
 
-newtype UserAssigns = UserAssigns {getUserAssigns :: Map Text Text}
-  deriving newtype (Show, Eq)
-
-emptyAssigns :: TemplateAssigns
-emptyAssigns = TemplateAssigns Map.empty
-
-mkAssigns :: TemplateAssigns -> Maybe UserAssigns -> TemplateAssigns
-mkAssigns (TemplateAssigns templateAssigns) (Just (UserAssigns userAssigns)) =
-  TemplateAssigns $ Map.union templateAssigns userAssigns
-mkAssigns ta Nothing = ta
-
-getTA :: TemplateAssigns -- ^  Template Assigns
-      -> Text -- ^ Default value if the key is not present
-      -> Text -- ^ Key
-      -> Text
-getTA (TemplateAssigns templateAssigns) defaultValue key = Map.findWithDefault defaultValue key templateAssigns
+defaultTemplateEnv :: TemplateEnv
+defaultTemplateEnv = TemplateEnv
+  { displayNavbarSearch = True
+  , flashInfo = Nothing
+  , flashError = Nothing
+  , title = "Flora :: [Package]"
+  , description = "Package index for the Haskell ecosystem"
+  }


### PR DESCRIPTION
## Proposed changes

This PR removes the usage of a `Map Text Text` to inject values in a template (the "assigns" pattern) and goes with a record that has a default value instead.