### PR TITLE
disable tests for pg-entity and pg-transacts

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -17,10 +17,11 @@ import ./pin.nix {
                 url = "https://github.com/flora-pm/wai-middleware-heartbeat/archive/bd7dbbe.tar.gz";
                 sha256 = "1s2flv2jhfnd4vdfg6rmvq7s852w1pypasdg0l6ih6raaqyqzybn";
             }) {};
-            pg-entity = hpNew.callCabal2nix "pg-entity" (fetchTarball {
+            pg-entity = pkgs.haskell.lib.dontCheck (hpNew.callCabal2nix "pg-entity" (fetchTarball {
                 url = "https://github.com/tchoutri/pg-entity/archive/e5fc4cf.tar.gz";
                 sha256 = "06fbjim83mbpv9ixacq40ir3cfzdy4dbkqx5pawc8z0n8ncwb9zq";
-              }) {};
+            }) {});
+            pg-transact = pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.unmarkBroken hpOld.pg-transact);
             hspec-pg-transact = pkgs.haskell.lib.dontCheck (hpOld.hspec-pg-transact);
             postgresql-migration = pkgs.haskell.lib.unmarkBroken hpOld.postgresql-migration;
             text-display = pkgs.haskell.lib.unmarkBroken hpOld.text-display;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -26,6 +26,8 @@ import ./pin.nix {
             postgresql-migration = pkgs.haskell.lib.unmarkBroken hpOld.postgresql-migration;
             text-display = pkgs.haskell.lib.unmarkBroken hpOld.text-display;
 
+            pcre2 = hpOld.callHackage "pcre2" "2.0.3" {};
+            optics-core = hpOld.callHackage "optics-core" "0.4" {};
             servant-lucid = hpOld.callHackage "servant-lucid" "0.9.0.3" {};
             envparse = hpNew.callCabal2nix "envparse" (fetchTarball {
                 url = "https://github.com/supki/envparse/archive/de5944f.tar.gz";


### PR DESCRIPTION
This disables running tests for pg-entity and pg-transacts.

I think both these testsuites want postgres to be available, 
which won't work in a nix build container.

I also fixed cabal issues for pcre2 and optics-core.
I don't know how to solve the lucid one (without modifying the cabal file)

Note that this targets the `fix-nix` branch.