### PR TITLE
Add assets deps dependency for asset build in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: ## Build the server without optimisations
 assets-deps: ## Install the dependencies of the frontend
 	@cd assets/ && yarn
 
-assets-build: ## Build the web assets
+assets-build: assets-deps ## Build the web assets
 	@cd assets/ && yarn build
 
 assets-watch: ## Continuously rebuild the web assets


### PR DESCRIPTION
## Proposed changes

this will make it run before doing asset build.
I couldn't figure this out yesterday at night,
this should make that easier.

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
