### PR TITLE
Set cabal version in default.nix instead of pkgs.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,9 @@ let
   ignore = import ./nix/gitignoreSource.nix { inherit (pkgs) lib; };
   # https://github.com/NixOS/nixpkgs/blob/dbacb52ad8/pkgs/development/haskell-modules/make-package-set.nix#L216
   src = ignore.gitignoreSource ./.;
-  cabal2nix = hpkgs.callCabal2nix "flora-server" src { };
+  cabal2nix = hpkgs.callCabal2nix "flora-server" src {
+    Cabal = hpkgs.callHackage "Cabal" "3.6.2.0" { };
+  };
   # https://github.com/NixOS/nixpkgs/blob/dbacb52ad8/pkgs/development/haskell-modules/generic-builder.nix#L13
 
 in pkgs.haskell.lib.overrideCabal cabal2nix (drv: {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -12,7 +12,6 @@ import ./pin.nix {
             };
           in {
             flora-server = hpNew.callPackage ../default.nix {
-              Cabal = hpOld.callHackage "Cabal" "3.6.2.0" { };
             };
             wai-middleware-heartbeat =
               hpNew.callCabal2nix "wai-middleware-heartbeat" (fetchTarball {


### PR DESCRIPTION
I think that version set before wasn't used at all.
I'm not sure why that {} is used if not for evaluating cabal.

This is a little ugly, but so is nix in general.

(note this targets the add-user-sessions branch again).