### PR TITLE
Upgrade http client

### DIFF
--- a/nix/cabal2nix/http-client.nix
+++ b/nix/cabal2nix/http-client.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, array, async, base, base64-bytestring
+, blaze-builder, bytestring, case-insensitive, containers, cookie
+, deepseq, directory, exceptions, fetchgit, filepath, ghc-prim
+, hspec, http-types, iproute, lib, mime-types, monad-control
+, network, network-uri, random, stm, streaming-commons, text, time
+, transformers, zlib
+}:
+mkDerivation {
+  pname = "http-client";
+  version = "0.7.10";
+  src = fetchgit {
+    url = "https://github.com/snoyberg/http-client";
+    sha256 = "050g09q0svlvyf480ars3lh1gwkz7cr0h86x439f5awlj3pwzxln";
+    rev = "105be4031597c5a5ab92963c87fc435a3bf1de25";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/http-client; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    array base base64-bytestring blaze-builder bytestring
+    case-insensitive containers cookie deepseq exceptions filepath
+    ghc-prim http-types iproute mime-types network network-uri random
+    stm streaming-commons text time transformers
+  ];
+  testHaskellDepends = [
+    async base blaze-builder bytestring case-insensitive containers
+    cookie deepseq directory hspec http-types monad-control network
+    network-uri streaming-commons text time transformers zlib
+  ];
+  doCheck = false;
+  homepage = "https://github.com/snoyberg/http-client";
+  description = "An HTTP client engine";
+  license = lib.licenses.mit;
+}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -31,6 +31,10 @@ import ./pin.nix {
             postgresql-migration =
               pkgs.haskell.lib.unmarkBroken hpOld.postgresql-migration;
             text-display = pkgs.haskell.lib.unmarkBroken hpOld.text-display;
+            # this is the old way of calling packages, I just ran cabal2nix
+            # and put it in that http-client.nix file.
+            # this prevents the cycle (nix'es callHackage uses cabal2nix which uses http-client apparently)
+            http-client = hpNew.callPackage ./cabal2nix/http-client.nix { };
 
             # here use hpNew to pull in data-sketches
             prometheus-client =

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -8,6 +8,7 @@ pkgs.runCommand "run-tests" ({ POSTGRES = pkgs.postgresql; }) ''
 
   export PATH=$PATH:$POSTGRES/bin
   export LC_ALL=C.UTF-8
+  export FLORA_HTTP_PORT=80
   ln -s ${../migrations} ./migrations
   ${pkgs.haskellPackages.flora-server}/bin/flora-test
 


### PR DESCRIPTION
(note this targets add-user-session branch)

this is the old way of calling packages, I just ran cabal2nix
and put the result http-client.nix file.
this prevents the cycle:
    nix'es callHackage uses cabal2nix
    which uses http-client apparently.