### PR TITLE
Makefile: use /usr/bin/env bash rather than /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ help:
 
 UNAME := $(shell uname)
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 ifeq ($(UNAME), Darwin)
 	PROCS := $(shell sysctl -n hw.logicalcpu)


### PR DESCRIPTION
/bin/bash isn't guaranteed to exist by POSIX, and in fact does not exist
on NixOS. /usr/bin/env is guaranteed, on the other hand. This uses
whatever bash is on PATH, which on more conventional Linuces will
probably still be /bin/bash.

## Proposed changes

This shouldn't actually change anything wrt flora itself! Just making the build a little more portable.

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
