### PR TITLE
Automatic reload of frontend

### DIFF
--- a/assets/esbuild.config.js
+++ b/assets/esbuild.config.js
@@ -12,8 +12,8 @@ if (process.env.NODE_ENV === 'prod') {
 }
 
 esbuild.build({
-  entryPoints: ['./js/app.js'],
-  outfile: `${copyDest}/js/app.js`,
+  entryPoints: ['./js/app.js', './js/autoreload.js'],
+  outdir: `${copyDest}/js/`,
   bundle: true,
   sourcemap: sourcemap,
   minify: minify,

--- a/assets/js/autoreload.js
+++ b/assets/js/autoreload.js
@@ -1,0 +1,45 @@
+const initialReconnectDelay = 1000;
+const maxReconnectDelay = 16000;
+var currentReconnectDelay = initialReconnectDelay;
+
+const connectToServer = () => {
+  console.log("[+] Connecting to the autoreload websocket")
+  const autoreloadSocket = new WebSocket("ws://localhost:8083/sockets/autoreload");
+  autoreloadSocket.addEventListener('close',  onWebsocketClose);
+  autoreloadSocket.addEventListener('error', onWebsocketClose);
+  autoreloadSocket.addEventListener('open',  onWebsocketOpen);
+  autoreloadSocket.addEventListener('message',  onWebsocketMessage);
+}
+
+const onWebsocketOpen = (event) => {
+  console.log("[+] Connection to server established!");
+}
+
+const onWebsocketMessage = (event) => {
+  console.log({event});
+  if (window.connId === undefined || window.connId === null) {
+    window.connId = event.data;
+  }
+
+  if (window.connId !== event.data) {
+    console.log("[+] Reloading the page");
+    location.reload(true);
+  }
+}
+
+const onWebsocketClose = () => {
+  console.log("[!] Server disconnected, attempting to reconnect…");
+  window.connId = null;
+  setTimeout(() => {
+      reconnectToWebsocket();
+  }, currentReconnectDelay);
+}
+
+const reconnectToWebsocket = () => {
+  if(currentReconnectDelay < maxReconnectDelay) {
+      currentReconnectDelay*=2;
+  }
+  connectToServer();
+}
+
+connectToServer();

--- a/assets/js/autoreload.js
+++ b/assets/js/autoreload.js
@@ -3,33 +3,51 @@ const maxReconnectDelay = 16000;
 var currentReconnectDelay = initialReconnectDelay;
 
 const connectToServer = () => {
-  console.log("[+] Connecting to the autoreload websocket")
+  sessionStorage.setItem("connId", null);
+  console.log("[+] Connecting to the autoreload websocket…")
   const autoreloadSocket = new WebSocket("ws://localhost:8083/sockets/autoreload");
   autoreloadSocket.addEventListener('close',  onWebsocketClose);
   autoreloadSocket.addEventListener('error', onWebsocketClose);
-  autoreloadSocket.addEventListener('open',  onWebsocketOpen);
+  autoreloadSocket.addEventListener('open',  (event) => onWebsocketOpen(autoreloadSocket, event));
   autoreloadSocket.addEventListener('message',  onWebsocketMessage);
 }
 
-const onWebsocketOpen = (event) => {
+const onWebsocketOpen = (socket, event) => {
   console.log("[+] Connection to server established!");
+  socket.send("HELLO");
 }
 
 const onWebsocketMessage = (event) => {
   console.log({event});
-  if (window.connId === undefined || window.connId === null) {
-    window.connId = event.data;
+  console.log(event.data);
+  console.log(typeof sessionStorage.getItem("connId"));
+  console.log(`[+] connection Id from the server is: ${event.data}`);
+  console.log(`[+] connection Id in the session is: ${sessionStorage.getItem("connId")}`);
+
+  const sessionConnId = sessionStorage.getItem("connId");
+  if (sessionConnId === null || sessionConnId === "null" ) {
+    console.log("[+] session connId is the following type:");
+    console.log(typeof sessionStorage.getItem("connId"));
+    console.log("[+] Connection id is null");
+    console.log("[+] Saving the server connId into the sessionStorage")
+    sessionStorage.setItem("connId", event.data);
+  } else {
+    console.log("[+] session connId is the following type:");
+    console.log(typeof sessionStorage.getItem("connId"));
   }
 
-  if (window.connId !== event.data) {
+  if (sessionStorage.getItem("connId") !== event.data) {
+    console.log("[+] session storage connId is different from the event data");
     console.log("[+] Reloading the page");
     location.reload(true);
+  } else {
+    console.log("[+] session storage connId and server connId are similar");
   }
 }
 
 const onWebsocketClose = () => {
   console.log("[!] Server disconnected, attempting to reconnect…");
-  window.connId = null;
+  sessionStorage.setItem("connId", null);
   setTimeout(() => {
       reconnectToWebsocket();
   }, currentReconnectDelay);

--- a/assets/js/autoreload.js
+++ b/assets/js/autoreload.js
@@ -2,6 +2,8 @@ const initialReconnectDelay = 1000;
 const maxReconnectDelay = 16000;
 var currentReconnectDelay = initialReconnectDelay;
 
+var wasConnectionLost = false;
+
 const connectToServer = () => {
   sessionStorage.setItem("connId", null);
   console.log("[+] Connecting to the autoreload websocket…")
@@ -9,45 +11,18 @@ const connectToServer = () => {
   autoreloadSocket.addEventListener('close',  onWebsocketClose);
   autoreloadSocket.addEventListener('error', onWebsocketClose);
   autoreloadSocket.addEventListener('open',  (event) => onWebsocketOpen(autoreloadSocket, event));
-  autoreloadSocket.addEventListener('message',  onWebsocketMessage);
 }
 
 const onWebsocketOpen = (socket, event) => {
   console.log("[+] Connection to server established!");
-  socket.send("HELLO");
-}
-
-const onWebsocketMessage = (event) => {
-  console.log({event});
-  console.log(event.data);
-  console.log(typeof sessionStorage.getItem("connId"));
-  console.log(`[+] connection Id from the server is: ${event.data}`);
-  console.log(`[+] connection Id in the session is: ${sessionStorage.getItem("connId")}`);
-
-  const sessionConnId = sessionStorage.getItem("connId");
-  if (sessionConnId === null || sessionConnId === "null" ) {
-    console.log("[+] session connId is the following type:");
-    console.log(typeof sessionStorage.getItem("connId"));
-    console.log("[+] Connection id is null");
-    console.log("[+] Saving the server connId into the sessionStorage")
-    sessionStorage.setItem("connId", event.data);
-  } else {
-    console.log("[+] session connId is the following type:");
-    console.log(typeof sessionStorage.getItem("connId"));
-  }
-
-  if (sessionStorage.getItem("connId") !== event.data) {
-    console.log("[+] session storage connId is different from the event data");
-    console.log("[+] Reloading the page");
+  if (wasConnectionLost) {
     location.reload(true);
-  } else {
-    console.log("[+] session storage connId and server connId are similar");
   }
 }
 
 const onWebsocketClose = () => {
   console.log("[!] Server disconnected, attempting to reconnect…");
-  sessionStorage.setItem("connId", null);
+  wasConnectionLost = true;
   setTimeout(() => {
       reconnectToWebsocket();
   }, currentReconnectDelay);

--- a/cabal.project
+++ b/cabal.project
@@ -6,8 +6,6 @@ with-compiler: ghc-8.10.7
 
 jobs: 8
 
-optimization: False
-
 tests: True
 
 allow-newer: all
@@ -16,6 +14,7 @@ test-show-details: direct
 
 package *
   ghc-options: "-L /usr/pgsql-14/lib"
+  flags: -prod
 
 package warp
   flags: -x509

--- a/flora.cabal
+++ b/flora.cabal
@@ -16,6 +16,13 @@ source-repository head
   type:     git
   location: https://github.com/flora/server
 
+flag prod
+  description:
+    Compile the project with additional optimisations (takes longer)  
+
+  default:     False
+  manual:      True
+
 common common-extensions
   default-extensions:
     NoMonomorphismRestriction
@@ -58,7 +65,7 @@ common common-ghc-options
     -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
     -fhide-source-paths -Wno-unused-do-bind -fshow-hole-constraints
 
-  if flag(release-build)
+  if flag(prod)
     ghc-options: -flate-specialise -funbox-strict-fields
 
 common common-rts-options
@@ -109,6 +116,7 @@ library
     Flora.Search
     Flora.ThirdParties.Hackage.API
     Flora.ThirdParties.Hackage.Client
+    FloraWeb.Autoreload
     FloraWeb.Client
     FloraWeb.Routes
     FloraWeb.Routes.Pages
@@ -194,6 +202,7 @@ library
     , servant-client-core        ^>=0.19
     , servant-lucid              ^>=0.9
     , servant-server             ^>=0.19
+    , servant-websockets         ^>=2.0
     , slugify                    ^>=0.1
     , souffle-haskell            ^>=3.3
     , text                       ^>=1.2
@@ -210,6 +219,7 @@ library
     , wai-middleware-heartbeat   ^>=0.0
     , wai-middleware-prometheus  ^>=1.0
     , warp                       ^>=3.3
+    , websockets                 ^>=0.12
 
 executable flora-server
   import:         common-extensions
@@ -286,10 +296,3 @@ test-suite flora-test
     Flora.PackageSpec
     Flora.TestUtils
     Flora.UserSpec
-
-flag release-build
-  description:
-    Compile the project with additional optimisations (takes longer)  
-
-  default:     False
-  manual:      True

--- a/flora.cabal
+++ b/flora.cabal
@@ -205,6 +205,7 @@ library
     , servant-websockets         ^>=2.0
     , slugify                    ^>=0.1
     , souffle-haskell            ^>=3.3
+    , template-haskell
     , text                       ^>=1.2
     , text-display               ^>=0.0.2
     , time                       ^>=1.9

--- a/src/FloraWeb/Autoreload.hs
+++ b/src/FloraWeb/Autoreload.hs
@@ -1,0 +1,31 @@
+module FloraWeb.Autoreload where
+
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ask)
+import qualified Data.UUID as UUID
+import FloraWeb.Server.Auth (FloraDevSocket)
+import qualified Log
+import Network.WebSockets (Connection)
+import qualified Network.WebSockets as Websockets
+import Servant
+import Servant.API.Generic
+import Servant.API.WebSocket
+
+type AutoreloadRoute = NamedRoutes AutoreloadRoute'
+data AutoreloadRoute' mode = AutoreloadRoute'
+  { autoreload :: mode :- "sockets" :> "autoreload" :> WebSocket
+  }
+  deriving stock (Generic)
+
+server :: ServerT AutoreloadRoute FloraDevSocket
+server =
+  AutoreloadRoute'
+    { autoreload = autoreloadHandler
+    }
+
+autoreloadHandler :: Connection -> FloraDevSocket ()
+autoreloadHandler connection = do
+  uuid <- ask
+  Log.logInfo_ $ "Sending " <> UUID.toText uuid
+  liftIO $ Websockets.receiveDataMessage connection
+  liftIO $ Websockets.sendTextData connection (UUID.toText uuid)

--- a/src/FloraWeb/Autoreload.hs
+++ b/src/FloraWeb/Autoreload.hs
@@ -1,11 +1,20 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module FloraWeb.Autoreload where
 
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (ask)
+import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as T
+import qualified Data.Text.Lazy.Encoding as TL
+import Data.UUID (UUID)
 import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUID
 import FloraWeb.Server.Auth (FloraDevSocket)
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
 import qualified Log
-import Network.WebSockets (Connection)
+import Network.WebSockets (Connection, DataMessage (..))
 import qualified Network.WebSockets as Websockets
 import Servant
 import Servant.API.Generic
@@ -27,5 +36,16 @@ autoreloadHandler :: Connection -> FloraDevSocket ()
 autoreloadHandler connection = do
   uuid <- ask
   Log.logInfo_ $ "Sending " <> UUID.toText uuid
-  liftIO $ Websockets.receiveDataMessage connection
+  Log.logInfo_ "lol"
+  liftIO $ Websockets.receiveDataMessage connection >>= printTextMessage
   liftIO $ Websockets.sendTextData connection (UUID.toText uuid)
+  autoreloadHandler connection
+
+printTextMessage :: (MonadIO m) => DataMessage -> m ()
+printTextMessage (Text bs _) =
+  liftIO $ T.putStrLn $ T.toStrict $ TL.decodeUtf8 bs
+printTextMessage _ = pure ()
+
+genUUID :: UUID
+genUUID = $(runIO UUID.nextRandom >>= lift)
+{-# NOINLINE genUUID #-}

--- a/src/FloraWeb/Autoreload.hs
+++ b/src/FloraWeb/Autoreload.hs
@@ -2,20 +2,8 @@
 
 module FloraWeb.Autoreload where
 
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (ask)
-import qualified Data.Text.IO as T
-import qualified Data.Text.Lazy as T
-import qualified Data.Text.Lazy.Encoding as TL
-import Data.UUID (UUID)
-import qualified Data.UUID as UUID
-import qualified Data.UUID.V4 as UUID
 import FloraWeb.Server.Auth (FloraDevSocket)
-import Language.Haskell.TH
-import Language.Haskell.TH.Syntax
-import qualified Log
-import Network.WebSockets (Connection, DataMessage (..))
-import qualified Network.WebSockets as Websockets
+import Network.WebSockets (Connection)
 import Servant
 import Servant.API.Generic
 import Servant.API.WebSocket
@@ -34,18 +22,4 @@ server =
 
 autoreloadHandler :: Connection -> FloraDevSocket ()
 autoreloadHandler connection = do
-  uuid <- ask
-  Log.logInfo_ $ "Sending " <> UUID.toText uuid
-  Log.logInfo_ "lol"
-  liftIO $ Websockets.receiveDataMessage connection >>= printTextMessage
-  liftIO $ Websockets.sendTextData connection (UUID.toText uuid)
   autoreloadHandler connection
-
-printTextMessage :: (MonadIO m) => DataMessage -> m ()
-printTextMessage (Text bs _) =
-  liftIO $ T.putStrLn $ T.toStrict $ TL.decodeUtf8 bs
-printTextMessage _ = pure ()
-
-genUUID :: UUID
-genUUID = $(runIO UUID.nextRandom >>= lift)
-{-# NOINLINE genUUID #-}

--- a/src/FloraWeb/Autoreload.hs
+++ b/src/FloraWeb/Autoreload.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module FloraWeb.Autoreload where
 
 import FloraWeb.Server.Auth (FloraDevSocket)

--- a/src/FloraWeb/Client.hs
+++ b/src/FloraWeb/Client.hs
@@ -4,43 +4,40 @@
 
 module FloraWeb.Client where
 
-import Control.Arrow ((>>>))
-import Lucid
 import Optics.Core
 import Servant (AuthProtect, Union)
-import Servant.API.Generic
 import Servant.Client
 import Servant.Client.Core
 import Servant.Client.Generic
 
-import Flora.Environment
 import Flora.Model.PersistentSession
 import Flora.Model.User.Orphans ()
 import FloraWeb.Routes as Web
+import qualified FloraWeb.Routes.Pages as Pages
 import qualified FloraWeb.Routes.Pages as Web
 import qualified FloraWeb.Routes.Pages.Sessions as Web
 import FloraWeb.Server.Auth
 import Lucid.Orphans ()
 import qualified Servant.Client.Core as Client
 
-type instance AuthClientData (AuthProtect "optional-cookie-auth") = Session 'Visitor
+-- type instance AuthClientData (AuthProtect "optional-cookie-auth") = Session 'Visitor
 
-floraClient :: Routes (AsClientT ClientM)
-floraClient = genericClient
+-- floraClient :: Pages.Routes (AsClientT ClientM)
+-- floraClient = genericClient
 
-fakeSession :: Session 'Visitor
-fakeSession =
-  let sessionId = PersistentSessionId $ read "8631b00a-f042-4751-9649-6b0aa617566f"
-      mUser = Nothing
-      webEnvStore = undefined
-   in Session{..}
+-- fakeSession :: Session 'Visitor
+-- fakeSession =
+--   let sessionId = PersistentSessionId $ read "8631b00a-f042-4751-9649-6b0aa617566f"
+--       mUser = Nothing
+--       webEnvStore = undefined
+--    in Session{..}
 
-anonymousRequest :: AuthenticatedRequest (AuthProtect "optional-cookie-auth")
-anonymousRequest = mkAuthenticatedRequest fakeSession addSessionCookie
+-- anonymousRequest :: AuthenticatedRequest (AuthProtect "optional-cookie-auth")
+-- anonymousRequest = mkAuthenticatedRequest fakeSession addSessionCookie
 
-addSessionCookie :: Session p -> Client.Request -> Client.Request
-addSessionCookie session req = Client.addHeader "cookie" (session ^. #sessionId) req
+-- addSessionCookie :: Session p -> Client.Request -> Client.Request
+-- addSessionCookie session req = Client.addHeader "cookie" (session ^. #sessionId) req
 
-createSession :: Web.LoginForm -> ClientM (Union Web.CreateSessionResponses)
-createSession loginForm =
-  floraClient // Web.pages /: anonymousRequest // Web.sessions // Web.create /: loginForm
+-- createSession :: Web.LoginForm -> ClientM (Union Web.CreateSessionResponses)
+-- createSession loginForm =
+--   floraClient // Web.pages /: anonymousRequest // Web.sessions // Web.create /: loginForm

--- a/src/FloraWeb/Routes.hs
+++ b/src/FloraWeb/Routes.hs
@@ -3,6 +3,7 @@ module FloraWeb.Routes where
 import Servant
 import Servant.API.Generic
 
+import FloraWeb.Autoreload (AutoreloadRoute)
 import qualified FloraWeb.Routes.Pages as Pages
 
 type ServerRoutes = NamedRoutes Routes
@@ -10,5 +11,6 @@ type ServerRoutes = NamedRoutes Routes
 data Routes mode = Routes
   { assets :: mode :- "static" :> Raw
   , pages :: mode :- AuthProtect "optional-cookie-auth" :> Pages.Routes
+  , autoreload :: mode :- AutoreloadRoute
   }
   deriving stock (Generic)

--- a/src/FloraWeb/Server.hs
+++ b/src/FloraWeb/Server.hs
@@ -1,6 +1,7 @@
 module FloraWeb.Server where
 
 import Colourista.IO (blueMessage)
+import Control.Exception (bracket)
 import Control.Monad (void, when)
 import Control.Monad.Reader
   ( MonadIO (liftIO)
@@ -8,13 +9,19 @@ import Control.Monad.Reader
   , withReaderT
   )
 import Data.Maybe (isJust)
+import qualified Data.Pool as Pool
 import Data.Text.Display (display)
+import qualified Data.UUID.V4 as UUID
+import qualified GHC.IO.Unsafe as Unsafe
+import Log (Logger, defaultLogLevel)
+import qualified Log
 import Network.Wai.Handler.Warp
   ( defaultSettings
   , runSettings
   , setOnException
   , setPort
   )
+import qualified Network.Wai.Log as WaiLog
 import Network.Wai.Middleware.Heartbeat (heartbeatMiddleware)
 import Optics.Core
 import qualified Prometheus
@@ -26,13 +33,14 @@ import Servant
   , Handler
   , HasServer (hoistServerWithContext)
   , Proxy (Proxy)
+  , hoistServer
   , serveDirectoryWebApp
   )
 import Servant.Server.Generic (AsServerT, genericServeTWithContext)
 
-import Control.Exception (bracket)
-import qualified Data.Pool as Pool
 import Flora.Environment (FloraEnv (..), LoggingEnv (..), getFloraEnv)
+import FloraWeb.Autoreload (AutoreloadRoute)
+import qualified FloraWeb.Autoreload as Autoreload
 import FloraWeb.Routes
 import qualified FloraWeb.Routes.Pages as Pages
 import FloraWeb.Server.Auth (FloraAuthContext, authHandler)
@@ -41,9 +49,6 @@ import FloraWeb.Server.Metrics
 import qualified FloraWeb.Server.Pages as Pages
 import FloraWeb.Server.Tracing
 import FloraWeb.Types
-import Log (Logger, defaultLogLevel)
-import qualified Log
-import qualified Network.Wai.Log as WaiLog
 
 runFlora :: IO ()
 runFlora = bracket getFloraEnv shutdownFlora $ \env -> do
@@ -85,10 +90,10 @@ runServer appLogger floraEnv = do
 
 mkServer :: Logger -> WebEnvStore -> FloraEnv -> Application
 mkServer logger webEnvStore floraEnv =
-  genericServeTWithContext (naturalTransform logger webEnvStore) (floraServer logger) (genAuthServerContext logger floraEnv)
+  genericServeTWithContext (naturalTransform logger webEnvStore) floraServer (genAuthServerContext logger floraEnv)
 
-floraServer :: Logger -> Routes (AsServerT FloraM)
-floraServer _logger =
+floraServer :: Routes (AsServerT FloraM)
+floraServer =
   Routes
     { assets = serveDirectoryWebApp "./static"
     , pages = \sessionWithCookies ->
@@ -97,7 +102,16 @@ floraServer _logger =
           (Proxy @'[FloraAuthContext])
           (\f -> withReaderT (const sessionWithCookies) f)
           Pages.server
+    , autoreload =
+        hoistServer
+          (Proxy @AutoreloadRoute)
+          ( \handler ->
+              let connId = Unsafe.unsafePerformIO UUID.nextRandom
+               in withReaderT (const connId) handler
+          )
+          Autoreload.server
     }
+{-# NOINLINE floraServer #-}
 
 naturalTransform :: Logger -> WebEnvStore -> FloraM a -> Handler a
 naturalTransform logger webEnvStore app =

--- a/src/FloraWeb/Server.hs
+++ b/src/FloraWeb/Server.hs
@@ -104,7 +104,7 @@ floraServer =
     , autoreload =
         hoistServer
           (Proxy @AutoreloadRoute)
-          ( \handler -> withReaderT (const Autoreload.genUUID) handler
+          ( \handler -> withReaderT (const ()) handler
           )
           Autoreload.server
     }

--- a/src/FloraWeb/Server.hs
+++ b/src/FloraWeb/Server.hs
@@ -67,7 +67,6 @@ shutdownFlora env = do
 
 runServer :: Logger -> FloraEnv -> IO ()
 runServer appLogger floraEnv = do
-  liftIO $ putStrLn "lol"
   loggingMiddleware <- Logging.runLog floraEnv appLogger WaiLog.mkLogMiddleware
   let webEnv = WebEnv floraEnv
   webEnvStore <- liftIO $ newWebEnvStore webEnv

--- a/src/FloraWeb/Server/Auth/Types.hs
+++ b/src/FloraWeb/Server/Auth/Types.hs
@@ -11,6 +11,7 @@ import Servant.Server
 import Servant.Server.Experimental.Auth (AuthServerData)
 import Web.Cookie (SetCookie)
 
+import Data.UUID (UUID)
 import Flora.Model.PersistentSession
 import Flora.Model.User
 import FloraWeb.Types
@@ -32,6 +33,9 @@ type FloraPageM = ReaderT (Headers '[Header "Set-Cookie" SetCookie] (Session 'Vi
 
 -- | Datatypes used for routes that *need* an admin
 type FloraAdminM = ReaderT (Headers '[Header "Set-Cookie" SetCookie] (Session 'Admin)) (LogT Handler)
+
+-- | The monad for the development websockets
+type FloraDevSocket = ReaderT UUID (LogT Handler)
 
 type instance
   AuthServerData (AuthProtect "optional-cookie-auth") =

--- a/src/FloraWeb/Server/Auth/Types.hs
+++ b/src/FloraWeb/Server/Auth/Types.hs
@@ -11,7 +11,6 @@ import Servant.Server
 import Servant.Server.Experimental.Auth (AuthServerData)
 import Web.Cookie (SetCookie)
 
-import Data.UUID (UUID)
 import Flora.Model.PersistentSession
 import Flora.Model.User
 import FloraWeb.Types
@@ -35,7 +34,7 @@ type FloraPageM = ReaderT (Headers '[Header "Set-Cookie" SetCookie] (Session 'Vi
 type FloraAdminM = ReaderT (Headers '[Header "Set-Cookie" SetCookie] (Session 'Admin)) (LogT Handler)
 
 -- | The monad for the development websockets
-type FloraDevSocket = ReaderT UUID (LogT Handler)
+type FloraDevSocket = ReaderT () (LogT Handler)
 
 type instance
   AuthServerData (AuthProtect "optional-cookie-auth") =

--- a/src/FloraWeb/Templates.hs
+++ b/src/FloraWeb/Templates.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module FloraWeb.Templates
   ( render
   , renderUVerb
@@ -11,28 +13,31 @@ import Control.Monad.Reader
 import Data.ByteString.Lazy
 import Lucid
 
+import Data.Text (Text)
+import Flora.Environment (DeploymentEnv (..))
 import FloraWeb.Templates.Layout.App (header)
 import FloraWeb.Templates.Types as Types
+import Optics.Core
 
 render :: (Monad m) => TemplateEnv -> FloraHTML -> m (Html ())
 render env template =
-  pure $
-    toHtmlRaw $
-      runIdentity $
-        runReaderT (renderBST (rendered template)) env
+  let deploymentEnv = env ^. #environment
+   in pure $ toHtmlRaw $ runIdentity $ runReaderT (renderBST (rendered deploymentEnv template)) env
 
 renderUVerb :: TemplateEnv -> FloraHTML -> Html ()
 renderUVerb env template =
-  toHtmlRaw $
-    runIdentity $
-      runReaderT (renderBST (rendered template)) env
+  let deploymentEnv = env ^. #environment
+   in toHtmlRaw $ runIdentity $ runReaderT (renderBST (rendered deploymentEnv template)) env
 
 mkErrorPage :: TemplateEnv -> FloraHTML -> ByteString
 mkErrorPage env template =
-  runIdentity $
-    runReaderT (renderBST (rendered template)) env
+  let deploymentEnv = env ^. #environment
+   in runIdentity $ runReaderT (renderBST (rendered deploymentEnv template)) env
 
-rendered :: FloraHTML -> FloraHTML
-rendered target = do
+rendered :: DeploymentEnv -> FloraHTML -> FloraHTML
+rendered deploymentEnv target = do
   header
   main_ [] target
+  if deploymentEnv == Development
+    then script_ [src_ "/static/js/autoreload.js", type_ "module"] ("" :: Text)
+    else pure ()


### PR DESCRIPTION
## Proposed changes

This PR implements a websocket endpoint that keeps the browser updated about the state of the backend. If the backend restarts, then the frontend client triggers the reloading of the page.

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
