### PR TITLE
Use Servant custom errors to return 404 page when a package name or namespace fails to parse in the URL

### DIFF
--- a/src/Flora/Model/Package/Types.hs
+++ b/src/Flora/Model/Package/Types.hs
@@ -101,7 +101,7 @@ parseNamespace txt =
     else Nothing
 
 data PackageStatus = UnknownPackage | FullyImportedPackage
-  deriving stock (Eq, Show, Generic, Bounded, Enum, Ord)
+ deriving stock (Eq, Show, Generic, Bounded, Enum, Ord)
 
 parsePackageStatus :: ByteString -> Maybe PackageStatus
 parsePackageStatus "unknown" = pure UnknownPackage

--- a/src/FloraWeb/Routes/Pages/Packages.hs
+++ b/src/FloraWeb/Routes/Pages/Packages.hs
@@ -17,31 +17,31 @@ data Routes' mode = Routes'
   { index :: mode :- Get '[HTML] (Html ())
   , show ::
       mode
-        :- Capture "namespace" Namespace
-          :> Capture "package" PackageName
+        :- Capture' '[Lenient] "namespace" Namespace
+          :> Capture' '[Lenient] "package" PackageName
           :> Get '[HTML] (Html ())
   , showDependents ::
       mode
-        :- Capture "namespace" Namespace
-          :> Capture "package" PackageName
+        :- Capture' '[Lenient] "namespace" Namespace
+          :> Capture' '[Lenient] "package" PackageName
           :> "dependents"
           :> Get '[HTML] (Html ())
   , showDependencies ::
       mode
-        :- Capture "namespace" Namespace
-          :> Capture "package" PackageName
+        :- Capture' '[Lenient] "namespace" Namespace
+          :> Capture' '[Lenient] "package" PackageName
           :> "dependencies"
           :> Get '[HTML] (Html ())
   , showVersion ::
       mode
-        :- Capture "namespace" Namespace
-          :> Capture "package" PackageName
-          :> Capture "version" Version
+        :- Capture' '[Lenient] "namespace" Namespace
+          :> Capture' '[Lenient] "package" PackageName
+          :> Capture' '[Lenient] "version" Version
           :> Get '[HTML] (Html ())
   , listVersions ::
       mode
-        :- Capture "namespace" Namespace
-          :> Capture "package" PackageName
+        :- Capture' '[Lenient] "namespace" Namespace
+          :> Capture' '[Lenient] "package" PackageName
           :> "versions"
           :> Get '[HTML] (Html ())
   }


### PR DESCRIPTION
## Proposed changes

This should use [custom errors](https://docs.servant.dev/en/stable/cookbook/custom-errors/CustomErrors.html)

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
