### PR TITLE
Display the description if no readme is available

### DIFF
--- a/flora.cabal
+++ b/flora.cabal
@@ -86,6 +86,7 @@ library
     Flora.Environment
     Flora.Environment.Config
     Flora.Environment.OddJobs
+    Flora.Haddock
     Flora.Import.Categories
     Flora.Import.Categories.Tuning
     Flora.Import.Package
@@ -195,6 +196,7 @@ library
     , directory                  ^>=1.3
     , envparse                   ^>=0.5
     , filepath                   ^>=1.4
+    , haddock-library
     , http-api-data              ^>=0.4
     , http-client                ==0.7.10
     , http-client-tls

--- a/src/Flora/Haddock.hs
+++ b/src/Flora/Haddock.hs
@@ -1,0 +1,54 @@
+module Flora.Haddock where
+
+import Control.Applicative (liftA2)
+import Control.Monad (forM_)
+import Data.Foldable (toList)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text.Lazy as TL
+import qualified Documentation.Haddock.Markup as Haddock
+import Documentation.Haddock.Parser (parseParas, toRegular)
+import Documentation.Haddock.Types (DocMarkupH (..), Header (..), Hyperlink (..), MetaDoc (..))
+import Lucid
+
+import Debug.Trace
+
+renderHaddock :: String -> String
+renderHaddock = traceId . TL.unpack . renderText . Haddock.markup termsMarkup . toRegular . _doc . parseParas Nothing
+
+termsMarkup :: DocMarkupH () String (Html ())
+termsMarkup =
+  Markup
+    { markupEmpty = pure mempty
+    , markupString = const $ pure mempty
+    , markupParagraph = p_
+    , markupAppend = liftA2 (<>)
+    , markupIdentifier = \s -> code_ (toHtml s)
+    , markupIdentifierUnchecked = const $ pure mempty -- should never happen
+    , markupModule = const $ pure mempty -- i.e. filter these out
+    , markupWarning = div_ [class_ "warning"]
+    , markupEmphasis = em_
+    , markupBold = strong_
+    , markupMonospaced = \s -> if TL.length (renderText s) > 1 then pure mempty else s
+    , markupUnorderedList = undefined -- \elements -> ul_ (mapM_ id elements) ,
+    , markupOrderedList = undefined -- ol_,
+    , markupDefList = \items -> dl_ [] $
+        forM_ items $ \(dTerm, detail) -> do
+          dt_ [] dTerm
+          dd_ [] detail
+    , markupCodeBlock = const mempty
+    , markupTable = mconcat . toList
+    , markupHyperlink = \(Hyperlink urlString mLabel) ->
+        let url = Text.pack urlString
+            label = maybe url (LText.toStrict . renderText) mLabel
+         in a_ [href_ url] (toHtml @Text label)
+    , -- TODO: extract main part of hostname
+      markupAName = pure mempty
+    , markupPic = pure mempty
+    , markupMathInline = pure mempty
+    , markupMathDisplay = pure mempty
+    , markupProperty = pure mempty
+    , markupExample = pure mempty
+    , markupHeader = \(Header _lvl title) -> title
+    }

--- a/src/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/FloraWeb/Templates/Pages/Packages.hs
@@ -2,6 +2,7 @@ module FloraWeb.Templates.Pages.Packages where
 
 import Data.Foldable (fold)
 import Data.Text (Text, pack)
+import qualified Data.Text as Text
 import Data.Text.Display
 import Data.Time (defaultTimeLocale)
 import qualified Data.Time as Time
@@ -10,6 +11,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector as Vector
 import Distribution.Pretty (pretty)
 import qualified Distribution.SPDX.License as SPDX
+import qualified Flora.Haddock as Haddock
 import Flora.Model.Category (Category (..))
 import Flora.Model.Package.Types
   ( Namespace
@@ -17,6 +19,7 @@ import Flora.Model.Package.Types
   , PackageName
   )
 import Flora.Model.Release (Release (..), ReleaseMetadata (..), TextHtml (..))
+import FloraWeb.Components.Utils (text)
 import qualified FloraWeb.Links as Links
 import FloraWeb.Templates.Types (FloraHTML)
 import Lucid
@@ -121,7 +124,7 @@ packageBody
 displayReadme :: Release -> FloraHTML
 displayReadme release =
   case readme release of
-    Nothing -> toHtml @Text "no readme available"
+    Nothing -> toHtmlRaw (Text.pack $ Haddock.renderHaddock $ Text.unpack $ release ^. #metadata ^. #description)
     Just (MkTextHtml readme) -> relaxHtmlT readme
 
 displayReleaseVersion :: Release -> FloraHTML


### PR DESCRIPTION
## Proposed changes

This PR displays a release's description field if no README is found in the tarball. The description data is haddock-formatted text.

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
