### PR TITLE
chore: fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY scripts/.zshrc /root/.zshrc
 
 # build Haskell dependencies
 COPY Makefile cabal.project flora.cabal ./
+RUN cabal update
 RUN cabal build --only-dependencies -j8
 
 # Compile Souffle source files


### PR DESCRIPTION
The image from which the image is being built has older version of cabal. 

So running `cabal update` explicitly just before the `cabal build` fixes the issue with cabal failing to construct the dependency tree because of unknown package versions.