### PR TITLE
Make package sidebars sticky

### DIFF
--- a/src/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/FloraWeb/Templates/Pages/Packages.hs
@@ -103,7 +103,7 @@ packageBody
     div_ $ do
       div_ [class_ "package-body md:flex"] $ do
         div_ [class_ "package-left-column"] $ do
-          ul_ [class_ "package-left-rows grid-rows-3"] $ do
+          ul_ [class_ "package-left-rows grid-rows-3 md:sticky md:top-28"] $ do
             displayCategories categories
             displayLicense (metadata ^. #license)
             displayLinks packageName latestRelease metadata
@@ -112,7 +112,7 @@ packageBody
           div_ [class_ "grid-rows-3 package-readme"] $ do
             displayReadme latestRelease
         div_ [class_ "package-right-column md:max-w-xs"] $ do
-          ul_ [class_ "package-right-rows grid-rows-3"] $ do
+          ul_ [class_ "package-right-rows grid-rows-3 md:sticky md:top-28"] $ do
             displayInstructions packageName latestRelease
             displayMaintainer (metadata ^. #maintainer)
             displayDependencies (namespace, packageName) numberOfDependencies dependencies


### PR DESCRIPTION
## Proposed changes

When viewing a single package, make the sidebars on both side of the readme stick to the top of screen, so essential data is remains accessible when scrolling through long READMEs. This doesn't affect the page on mobile displays.

Here are before and after videos (don't mind the placeholder text)

https://user-images.githubusercontent.com/8615241/184170514-cad85391-4ead-475d-a027-d78d4e42d134.mov


https://user-images.githubusercontent.com/8615241/184170870-6cb3a23d-95b3-4b4c-813a-6a3a0e3b984f.mov


