### PR TITLE
Harmonise the size of the package title and version in mobile view

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -68,6 +68,19 @@ div[class="bullets"] {
   border-radius: 6px;
 }
 
+.package-title {
+  .headline {
+    font-size: xx-large;
+    line-height: 1;
+  }
+
+  .version {
+    font-size: medium;
+    line-height: 1.3rem;
+    padding-left: 4px;
+  }
+}
+
 .package-body {
   a {
     font-weight: 500;
@@ -283,12 +296,6 @@ li.dependents a.dependent:hover {
 
   .headline {
     margin-bottom: 5px;
-  }
-
-  .version {
-    font-size: 1.3rem;
-    line-height: 1.3rem;
-    padding-left: 4px;
   }
 
   .dependency {

--- a/src/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/FloraWeb/Templates/Pages/Packages.hs
@@ -72,7 +72,7 @@ presentationHeader :: Release -> Namespace -> PackageName -> Text -> FloraHTML
 presentationHeader release namespace name synopsis = do
   div_ [class_ "divider"] $ do
     div_ [class_ "px-4 py-5 sm:px-6 sm:py-24 lg:py-4 lg:px-8"] $
-      h2_ [class_ "text-center text-2xl tracking-tight sm:text-2xl lg:text-5xl"] $ do
+      h2_ [class_ "package-title text-center tracking-tight"] $ do
         span_ [class_ "headline"] $ toHtml namespace <> "/" <> toHtml name
         span_ [class_ "dark:text-gray-200 version"] $ displayReleaseVersion release
     div_ [class_ "synopsis lg:text-xl text-center"] $


### PR DESCRIPTION
fix #190

## Proposed changes

### Before

![Screenshot 2022-09-09 at 22-15-42 Flora Package](https://user-images.githubusercontent.com/15848443/189435947-3bd32aa6-23ab-4bb6-a39d-22d2b711cda2.png)

### After

![Screenshot 2022-09-09 at 22-12-46 Flora Package](https://user-images.githubusercontent.com/15848443/189435969-2ab398f2-a218-4788-9494-010d1822099d.png)


## Contributor checklist

- [ ] My PR is related to #190
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
