### PR TITLE
Generate request ID in Nginx

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,7 +10,7 @@ pull_request_rules:
     name: Put pull requests in the rebase+merge queue
     conditions:
       - label=merge me
-      - check-success=build: tests
+      - 'check-success~=Backend tests'
       # - '#approved-reviews-by>=1'
   # merge+squash strategy
   - actions:
@@ -23,7 +23,7 @@ pull_request_rules:
     name: Put pull requests in the squash+merge queue
     conditions:
       - label=squash+merge me
-      - check-success=build: tests
+      - 'check-success~=Backend tests'
       # - '#approved-reviews-by>=1'
 
 queue_rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Colourise the search bars on focus (#215)
 * Add OpenGraph metadata in package pages (#217)
+* Request ID in logging and traces (#224)
 
 ## v1.0.3 -- 2022-09-22
 

--- a/deployment/flora.nginx
+++ b/deployment/flora.nginx
@@ -24,16 +24,12 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
 
+
     access_log /var/log/nginx/flora_access.log;
     error_log /var/log/nginx/flora_error.log;
 
     # favicon
-    location = /favicon.ico {
-        log_not_found off;
-        access_log off;
-    }
-
-    location = /favicon.svg {
+    location ~ /favicon.(ico|svg) {
         log_not_found off;
         access_log off;
     }
@@ -62,12 +58,13 @@ server {
     }
 
     location / {
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Request-ID $request_id;
         proxy_redirect off;
         proxy_pass http://localhost:8083;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 }

--- a/src/FloraWeb/Server.hs
+++ b/src/FloraWeb/Server.hs
@@ -55,7 +55,7 @@ import FloraWeb.Autoreload (AutoreloadRoute)
 import FloraWeb.Autoreload qualified as Autoreload
 import FloraWeb.Routes
 import FloraWeb.Routes.Pages qualified as Pages
-import FloraWeb.Server.Auth (FloraAuthContext, authHandler, runVisitorSession)
+import FloraWeb.Server.Auth (FloraAuthContext, authHandler, runVisitorSession, requestID)
 import FloraWeb.Server.Logging (runLog)
 import FloraWeb.Server.Logging qualified as Logging
 import FloraWeb.Server.Metrics
@@ -63,6 +63,8 @@ import FloraWeb.Server.OpenSearch
 import FloraWeb.Server.Pages qualified as Pages
 import FloraWeb.Server.Tracing
 import FloraWeb.Types
+import Servant.API (getResponse)
+import qualified Data.Aeson as Aeson
 
 runFlora :: IO ()
 runFlora = bracket (runEff getFloraEnv) (runEff . shutdownFlora) $ \env -> runEff . runCurrentTimeIO . runConcurrent $ do
@@ -148,6 +150,7 @@ floraServer pool cfg jobsRunnerEnv =
               floraPage
                 & runVisitorSession
                 & runDB pool
+                & Log.localData [("request_id", Aeson.String $ requestID . getResponse $ sessionWithCookies)]
                 & runCurrentTimeIO
                 & withReader (const sessionWithCookies)
           )

--- a/src/FloraWeb/Server/Auth.hs
+++ b/src/FloraWeb/Server/Auth.hs
@@ -24,6 +24,8 @@ import Servant.Server
 import Servant.Server.Experimental.Auth (AuthHandler, mkAuthHandler)
 import Web.Cookie
 
+import Data.Text.Encoding qualified as Text
+import Data.UUID.V4 qualified as UUID
 import Flora.Environment
 import Flora.Model.PersistentSession
 import Flora.Model.User
@@ -32,8 +34,6 @@ import FloraWeb.Server.Auth.Types
 import FloraWeb.Server.Logging qualified as Logging
 import FloraWeb.Session
 import FloraWeb.Types
-import qualified Data.Text.Encoding as Text
-import qualified Data.UUID.V4 as UUID
 
 type FloraAuthContext = AuthHandler Request (Headers '[Header "Set-Cookie" SetCookie] Session)
 
@@ -41,11 +41,11 @@ authHandler :: Logger -> FloraEnv -> FloraAuthContext
 authHandler logger floraEnv =
   mkAuthHandler
     ( \request ->
-      handler request
-        & Logging.runLog (floraEnv.environment) logger
-        & DB.runDB (floraEnv.pool)
-        & runVisitorSession
-        & Servant.effToHandler
+        handler request
+          & Logging.runLog (floraEnv.environment) logger
+          & DB.runDB (floraEnv.pool)
+          & runVisitorSession
+          & Servant.effToHandler
     )
   where
     handler :: Request -> Eff '[Logging, DB, IsVisitor, Error ServerError, IOE] (Headers '[Header "Set-Cookie" SetCookie] Session)

--- a/src/FloraWeb/Server/Auth.hs
+++ b/src/FloraWeb/Server/Auth.hs
@@ -5,7 +5,9 @@ module FloraWeb.Server.Auth
   )
 where
 
+import Data.Function ((&))
 import Data.List qualified as List
+import Data.Text (Text)
 import Data.UUID qualified as UUID
 import Effectful
 import Effectful.Error.Static (Error, throwError)
@@ -30,7 +32,8 @@ import FloraWeb.Server.Auth.Types
 import FloraWeb.Server.Logging qualified as Logging
 import FloraWeb.Session
 import FloraWeb.Types
-import Data.Function ((&))
+import qualified Data.Text.Encoding as Text
+import qualified Data.UUID.V4 as UUID
 
 type FloraAuthContext = AuthHandler Request (Headers '[Header "Set-Cookie" SetCookie] Session)
 
@@ -51,6 +54,7 @@ authHandler logger floraEnv =
       mbPersistentSessionId <- handlerToEff $ getSessionId cookies
       mbPersistentSession <- getInTheFuckingSessionShinji mbPersistentSessionId
       mUserInfo <- fetchUser mbPersistentSession
+      requestID <- liftIO $ getRequestID req
       (mUser, sessionId) <- do
         case mUserInfo of
           Nothing -> do
@@ -67,6 +71,13 @@ getCookies req =
   maybe [] parseCookies (List.lookup hCookie headers)
   where
     headers = requestHeaders req
+
+getRequestID :: Request -> IO Text
+getRequestID req = do
+  let headers = requestHeaders req
+  case List.lookup "X-Request-ID" headers of
+    Nothing -> fmap UUID.toText UUID.nextRandom
+    Just requestID -> pure $ Text.decodeUtf8 requestID
 
 getSessionId :: Cookies -> Handler (Maybe PersistentSessionId)
 getSessionId cookies =

--- a/src/FloraWeb/Server/Auth/Types.hs
+++ b/src/FloraWeb/Server/Auth/Types.hs
@@ -1,9 +1,11 @@
 module FloraWeb.Server.Auth.Types where
 
+import Data.Kind (Type)
 import Effectful
 import Effectful.Dispatch.Static
 import Effectful.Error.Static (Error)
 import Effectful.Log (Logging)
+import Effectful.PostgreSQL.Transact.Effect (DB)
 import Effectful.Reader.Static (Reader)
 import Effectful.Time (Time)
 import GHC.Generics
@@ -12,16 +14,16 @@ import Servant.Server
 import Servant.Server.Experimental.Auth (AuthServerData)
 import Web.Cookie (SetCookie)
 
-import Data.Kind (Type)
-import Effectful.PostgreSQL.Transact.Effect (DB)
 import Flora.Model.PersistentSession
 import Flora.Model.User
 import FloraWeb.Types
+import Data.Text (Text)
 
 data Session = Session
   { sessionId :: PersistentSessionId
   , mUser :: Maybe User
   , webEnvStore :: WebEnvStore
+  , requestID :: Text
   }
   deriving stock (Generic)
 

--- a/src/FloraWeb/Server/Auth/Types.hs
+++ b/src/FloraWeb/Server/Auth/Types.hs
@@ -14,10 +14,10 @@ import Servant.Server
 import Servant.Server.Experimental.Auth (AuthServerData)
 import Web.Cookie (SetCookie)
 
+import Data.Text (Text)
 import Flora.Model.PersistentSession
 import Flora.Model.User
 import FloraWeb.Types
-import Data.Text (Text)
 
 data Session = Session
   { sessionId :: PersistentSessionId


### PR DESCRIPTION
## Proposed changes

This PR fixes #224 by fetching a request ID from the web proxy (or generate one locally), and injects it in log statement metadata. It is stored in the Session. 

## Contributor checklist

- [x] My PR is related to #224
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
