### PR TITLE
[FLORA-226] Enforce ticket in PR title or first commit

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,7 +10,7 @@ pull_request_rules:
     name: Put pull requests in the rebase+merge queue
     conditions:
       - label=merge me
-      - 'check-success~=Backend tests'
+      - 'check-success=Backend tests / tests'
       # - '#approved-reviews-by>=1'
   # merge+squash strategy
   - actions:
@@ -23,7 +23,7 @@ pull_request_rules:
     name: Put pull requests in the squash+merge queue
     conditions:
       - label=squash+merge me
-      - 'check-success~=Backend tests'
+      - 'check-success~=Backend tests / tests'
       # - '#approved-reviews-by>=1'
 
 queue_rules:

--- a/.github/workflows/check-flora-tickets-in-prs.yaml
+++ b/.github/workflows/check-flora-tickets-in-prs.yaml
@@ -1,0 +1,22 @@
+jobs:
+  make-sure-titles-contain-flora-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: "actions/checkout@v2"
+        with:
+          ref: "${{ github.head_ref }}"
+      - name: Make sure there is one proper commit or PR title
+        env:
+          PULL_REQUEST_TITLE: "${{ github.event.pull_request.title }}"
+          GITHUB_TOKEN: "${{ github.token }}"
+          PULL_REQUEST_COMMITS_URL: "${{ github.event.pull_request.commits_url }}"
+          PULL_REQUEST_AUTHOR: "${{ github.event.pull_request.user.login }}"
+        run: |
+          ./.github/workflows/check-ticket-in-prs.sh
+name: Make sure PR has FLORA issue in title or has one commit with FLORA issue
+on:
+  pull_request:
+    types:
+      - synchronize
+      - edited

--- a/.github/workflows/check-ticket-in-prs.sh
+++ b/.github/workflows/check-ticket-in-prs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+COMMIT_MESSAGE_PATTERN="\[((FLORA)-[0-9]+)|NO-ISSUE\]"
+COMMIT_MESSAGES_FILE=$(mktemp /tmp/commit-messages-XXXX.tmp)
+
+trap "rm ${COMMIT_MESSAGES_FILE}" EXIT
+
+curl \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  $PULL_REQUEST_COMMITS_URL \
+  | jq ".[] | .commit.message" -r > $COMMIT_MESSAGES_FILE
+
+if [ "$PULL_REQUEST_AUTHOR" == "dependabot" ]; then
+  echo "Pull request by dependabot - not checking"
+  exit 0
+else
+  echo "$PULL_REQUEST_TITLE" | grep -E "${COMMIT_MESSAGE_PATTERN}"
+  if [ $? -ne 0 ]; then
+    echo "Pull request title doesn't start with '[FLORA-ISSUE]' or '[NO-ISSUE]'" > /dev/stderr
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Proposed changes

This PR brings a new Github Action that checks for the `[FLORA-XXX] | [NO-ISSUE]` pattern in PR titles and git commit.

## Contributor checklist

- [x] My PR is related to #226
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
