### PR TITLE
[FLORA-205] Enable the use of markdown extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.5 -- XXXX-XX-XX
 
 * Reorder the package page columns in mobile view (#233)
+* Enable the use of markdown extensions in package READMEs (#236)
 
 ## v1.0.4 -- 2022-10-02
 

--- a/src/Flora/OddJobs.hs
+++ b/src/Flora/OddJobs.hs
@@ -126,18 +126,18 @@ makeReadme pay@MkReadmePayload{..} = localDomain "fetch-readme" $ do
         let extensions =
               mconcat
                 [ Commonmark.Extensions.mathSpec
-                -- all gfm extensions apart from pipeTable
-                , Commonmark.Extensions.emojiSpec
+                , -- all gfm extensions apart from pipeTable
+                  Commonmark.Extensions.emojiSpec
                 , Commonmark.Extensions.strikethroughSpec
                 , Commonmark.Extensions.autolinkSpec
                 , Commonmark.Extensions.autoIdentifiersSpec
                 , Commonmark.Extensions.taskListSpec
                 , Commonmark.Extensions.footnoteSpec
-                -- default syntax
-                , Commonmark.defaultSyntaxSpec
-                -- pipe table spec. This has to be after default syntax due to
-                -- https://github.com/jgm/commonmark-hs/issues/95
-                , Commonmark.Extensions.pipeTableSpec
+                , -- default syntax
+                  Commonmark.defaultSyntaxSpec
+                , -- pipe table spec. This has to be after default syntax due to
+                  -- https://github.com/jgm/commonmark-hs/issues/95
+                  Commonmark.Extensions.pipeTableSpec
                 ]
         Commonmark.commonmarkWith extensions ("readme " <> show mpPackage) bodyText
           >>= \case

--- a/src/Flora/OddJobs.hs
+++ b/src/Flora/OddJobs.hs
@@ -123,21 +123,22 @@ makeReadme pay@MkReadmePayload{..} = localDomain "fetch-readme" $ do
       logInfo ("got a body for package " <> display mpPackage) (object ["release_id" .= mpReleaseId])
 
       htmlTxt <- do
-        let extensions = mconcat
-              [ Commonmark.Extensions.mathSpec
-              -- all gfm extensions apart from pipeTable
-              , Commonmark.Extensions.emojiSpec
-              , Commonmark.Extensions.strikethroughSpec
-              , Commonmark.Extensions.autolinkSpec
-              , Commonmark.Extensions.autoIdentifiersSpec
-              , Commonmark.Extensions.taskListSpec
-              , Commonmark.Extensions.footnoteSpec
-              -- default syntax
-              , Commonmark.defaultSyntaxSpec
-              -- pipe table spec. This has to be after default syntax due to
-              -- https://github.com/jgm/commonmark-hs/issues/95
-              , Commonmark.Extensions.pipeTableSpec
-              ]
+        let extensions =
+              mconcat
+                [ Commonmark.Extensions.mathSpec
+                -- all gfm extensions apart from pipeTable
+                , Commonmark.Extensions.emojiSpec
+                , Commonmark.Extensions.strikethroughSpec
+                , Commonmark.Extensions.autolinkSpec
+                , Commonmark.Extensions.autoIdentifiersSpec
+                , Commonmark.Extensions.taskListSpec
+                , Commonmark.Extensions.footnoteSpec
+                -- default syntax
+                , Commonmark.defaultSyntaxSpec
+                -- pipe table spec. This has to be after default syntax due to
+                -- https://github.com/jgm/commonmark-hs/issues/95
+                , Commonmark.Extensions.pipeTableSpec
+                ]
         Commonmark.commonmarkWith extensions ("readme " <> show mpPackage) bodyText
           >>= \case
             Left exception -> throw (MarkdownFailed exception)

--- a/src/Flora/OddJobs.hs
+++ b/src/Flora/OddJobs.hs
@@ -123,24 +123,22 @@ makeReadme pay@MkReadmePayload{..} = localDomain "fetch-readme" $ do
       logInfo ("got a body for package " <> display mpPackage) (object ["release_id" .= mpReleaseId])
 
       htmlTxt <- do
-        let
-          extensions = mconcat
-            [ Commonmark.Extensions.mathSpec
-            -- all gfm extensions apart from pipeTable
-            , Commonmark.Extensions.emojiSpec
-            , Commonmark.Extensions.strikethroughSpec
-            , Commonmark.Extensions.autolinkSpec
-            , Commonmark.Extensions.autoIdentifiersSpec
-            , Commonmark.Extensions.taskListSpec
-            , Commonmark.Extensions.footnoteSpec
-            -- default syntax
-            , Commonmark.defaultSyntaxSpec
-            -- pipe table spec. This has to be after default syntax due to
-            -- https://github.com/jgm/commonmark-hs/issues/95
-            , Commonmark.Extensions.pipeTableSpec
-            ]
+        let extensions = mconcat
+              [ Commonmark.Extensions.mathSpec
+              -- all gfm extensions apart from pipeTable
+              , Commonmark.Extensions.emojiSpec
+              , Commonmark.Extensions.strikethroughSpec
+              , Commonmark.Extensions.autolinkSpec
+              , Commonmark.Extensions.autoIdentifiersSpec
+              , Commonmark.Extensions.taskListSpec
+              , Commonmark.Extensions.footnoteSpec
+              -- default syntax
+              , Commonmark.defaultSyntaxSpec
+              -- pipe table spec. This has to be after default syntax due to
+              -- https://github.com/jgm/commonmark-hs/issues/95
+              , Commonmark.Extensions.pipeTableSpec
+              ]
         Commonmark.commonmarkWith extensions ("readme " <> show mpPackage) bodyText
-        -- pure (Commonmark.commonmark ("readme " <> show mpPackage) bodyText)
           >>= \case
             Left exception -> throw (MarkdownFailed exception)
             Right (y :: Commonmark.Html ()) -> pure $ Commonmark.renderHtml y


### PR DESCRIPTION
## Proposed changes

Enable the same commonmark extensions that Hackage does

## Contributor checklist

- [x] My PR is related to #205
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
