### PR TITLE
[FLORA-255] Fix the `dependents` view to include other namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.6 -- XXXX-XX-XX
+
+* Fix the `dependents` materialized view (#256)
+
 ## v1.0.5 -- 2022-10-22
 
 * Reorder the package page columns in mobile view (#233)

--- a/environment.test.sh
+++ b/environment.test.sh
@@ -1,4 +1,4 @@
-. environment.sh
+. ./environment.sh
 
 export FLORA_HTTP_PORT=8085
 export FLORA_ENVIRONMENT="test"

--- a/ghc-tags.yaml
+++ b/ghc-tags.yaml
@@ -5,7 +5,6 @@ exclude_paths:
 - dist
 - dist-newstyle
 - assets
-language: GHC2021
 extensions:
 - BangPatterns
 - BlockArguments

--- a/migrations/20211113195849_create_dependents.sql
+++ b/migrations/20211113195849_create_dependents.sql
@@ -23,7 +23,7 @@ create materialized view dependents (
     inner join "package_components" as pc2 on pc2."release_id" = r1."release_id"
     inner join "requirements" as r3 on r3."package_component_id" = pc2."package_component_id"
     inner join "packages" as p4 on p4."package_id" = r3."package_id"
-  where (p4.name != p0.name) and (p4.namespace != p0.namespace);
+  where (p4.name, p4.namespace) != (p0.name, p0.namespace);
 
 create index on dependents (name, dependent_id);
 create unique index on dependents (name, namespace, dependent_id);

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,6 +9,7 @@ import Optics.Core
 import System.IO
 import Test.Tasty (defaultMain, testGroup)
 
+import Effectful.Fail (runFailIO)
 import Effectful.Log qualified as Log
 import Flora.CabalSpec qualified as CabalSpec
 import Flora.CategorySpec qualified as CategorySpec
@@ -27,6 +28,7 @@ main = do
     runCurrentTimeIO
     . Log.runLog "flora-test" stdOutLogger LogAttention
     . runDB (env ^. #pool)
+    . runFailIO
     $ do
       testMigrations
       f' <- getFixtures


### PR DESCRIPTION
## Proposed changes

Fix the `dependents` view to include other namespaces

## Contributor checklist

- [x] My PR fixes #255 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
