### PR TITLE
[NO-ISSUE] Fix package title size in smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.0.9 -- XXXX-XX-XX
+* Fix package title size in smaller screens ([#297](https://github.com/flora-pm/flora-server/pull/297))
+
 ## 1.0.8 -- 2022-11-30
 * Display compiler version with which the package declares having been tested ([#249](https://github.com/flora-pm/flora-server/pull/249))
 * Promote exact matches when searching packages ([#284](https://github.com/flora-pm/flora-server/pull/284))

--- a/assets/css/compiler-badge.css
+++ b/assets/css/compiler-badge.css
@@ -1,7 +1,7 @@
 ul.compiler-badges {
   list-style: none;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, 80px);
 
   li {
     margin-left: 4px;
@@ -10,19 +10,15 @@ ul.compiler-badges {
     border-radius: 50rem;
     max-width: 100%;
     background-color: var(--compiler-badge-background);
+    text-align: center;
   }
 }
 
 a.compiler-badge {
-  padding-right: 4px;
-  padding-left: 4px;
   box-sizing: border-box;
-
-  span {
-    text-decoration: none;
-    display: inline-flex;
-    font-size: 0.9rem;
-    color: var(--text-color);
-    padding: 0.3em 0.6em;
-  }
+  color: var(--text-color);
+  display: inline-block;
+  font-size: 0.9rem;
+  padding: 0.3em 0.6em;
+  text-decoration: none;
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -165,8 +165,6 @@ div[class="bullets"] {
 /* Dark mode-specific rules */
 .dark {
   .social-button:hover {
-    --tw-text-opacity: 1;
-
     color: hsl(254.3 95% 76.7%);
   }
 }
@@ -188,6 +186,7 @@ div[class="bullets"] {
     line-height: 1;
     letter-spacing: -0.025em;
     text-align: center;
+    overflow-wrap: anywhere;
   }
 }
 
@@ -379,5 +378,15 @@ div[class="bullets"] {
     flex-direction: row;
     justify-content: center;
     align-items: flex-start;
+  }
+}
+
+/* Smol display rulz */
+
+@media (max-width: 1024px) {
+  .page-title {
+    h1 {
+      font-size: 2rem;
+    }
   }
 }

--- a/src/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/FloraWeb/Templates/Pages/Packages.hs
@@ -81,7 +81,7 @@ showPackage
 presentationHeader :: Release -> Namespace -> PackageName -> Text -> FloraHTML
 presentationHeader release namespace name synopsis = div_ [class_ "divider"] $ do
   div_ [class_ "page-title"] $
-    h1_ [class_ "package-title text-center tracking-tight"] $ do
+    h1_ [class_ "package-title"] $ do
       span_ [class_ "headline"] $ toHtml (display namespace) <> "/" <> toHtml name
       span_ [class_ "dark:text-gray-200 version"] $ displayReleaseVersion release.version
   div_ [class_ "synopsis lg:text-xl text-center"] $
@@ -234,9 +234,7 @@ displayTestedWith compilersVersions'
           forM_ compilersVersions $ \version -> do
             li_ [] $
               a_ [class_ "compiler-badge"] $
-                span_
-                  []
-                  (toHtml @Text (display version))
+                toHtml @Text (display version)
 
 displayMaintainer :: Text -> FloraHTML
 displayMaintainer maintainerInfo = li_ [class_ ""] $ do


### PR DESCRIPTION
## Proposed changes

The title of a page is brought to 2rem instead of 3 on smaller screens