### PR TITLE
[FLORA-132] Only index versionless package pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add buttons to the main page for ghcup and cabal guides ([#341](https://github.com/flora-pm/flora-server/pull/341))
 * Split the project into internal libraries ([#337](https://github.com/flora-pm/flora-server/pull/337)) 
 * Fetch and store deprecation information about packages ([#342](https://github.com/flora-pm/flora-server/pull/342))
+* Only index versionless package pages ([#343](https://github.com/flora-pm/flora-server/pull/343))
 
 ## 1.0.9 -- 2023-01-06
 * Fix package title size in smaller screens ([#297](https://github.com/flora-pm/flora-server/pull/297))

--- a/src/web/FloraWeb/Components/Header.hs
+++ b/src/web/FloraWeb/Components/Header.hs
@@ -3,7 +3,7 @@
 module FloraWeb.Components.Header where
 
 import Control.Monad.Reader
-import Data.Text
+import Data.Text (Text)
 import Lucid
 import Lucid.Alpine
 import PyF
@@ -15,7 +15,7 @@ import FloraWeb.Templates.Types (FloraHTML, TemplateEnv (..))
 
 header :: FloraHTML
 header = do
-  TemplateEnv{title} <- ask
+  TemplateEnv{title, indexPage} <- ask
   doctype_
   html_
     [ lang_ "en"
@@ -33,6 +33,7 @@ header = do
       head_ $! do
         meta_ [charset_ "UTF-8"]
         meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
+        unless indexPage $ meta_ [name_ "robots", content_ "noindex"]
         title_ (text title)
 
         script_ [type_ "module"] $! do

--- a/src/web/FloraWeb/Templates/Types.hs
+++ b/src/web/FloraWeb/Templates/Types.hs
@@ -53,6 +53,7 @@ data TemplateEnv = TemplateEnv
   , environment :: DeploymentEnv
   , activeElements :: ActiveElements
   , assets :: Assets
+  , indexPage :: Bool
   }
   deriving stock (Show, Generic)
 
@@ -75,6 +76,7 @@ data TemplateDefaults = TemplateDefaults
   , mUser :: Maybe User
   , environment :: DeploymentEnv
   , activeElements :: ActiveElements
+  , indexPage :: Bool
   }
   deriving stock (Show, Generic)
 
@@ -99,6 +101,7 @@ defaultTemplateEnv =
     , mUser = Nothing
     , environment = Development
     , activeElements = defaultActiveElements
+    , indexPage = True
     }
 
 -- | ⚠  DO NOT USE THIS FUNCTION IF YOU DON'T KNOW WHAT YOU'RE DOING


### PR DESCRIPTION
Adds the robots noindex meta tag on package pages unless they're explicitly versioned.

## Proposed changes

## Contributor checklist

- [x] My PR is related to #132 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
