### PR TITLE
[FLORA-142] Add components to dependencies page

### DIFF
--- a/.github/workflows/check-flora-tickets-in-prs.yaml
+++ b/.github/workflows/check-flora-tickets-in-prs.yaml
@@ -5,7 +5,8 @@ jobs:
       - name: Checkout Code
         uses: "actions/checkout@v3"
         with:
-          ref: "${{ github.head_ref }}"
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Make sure there is one proper commit or PR title
         env:
           PULL_REQUEST_TITLE: "${{ github.event.pull_request.title }}"

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,6 +20,26 @@ body {
   color: var(--text-color);
 }
 
+details > summary {
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1.25rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding-left: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+details summary > * {
+  display: inline;
+}
+
+details > summary:hover {
+  background-color: var(--package-list-item-background-hover-color);
+  border-radius: 6px;
+}
+
 .larger-container {
   margin-left: auto;
   margin-right: auto;

--- a/src/web/FloraWeb/Server/Pages/Packages.hs
+++ b/src/web/FloraWeb/Server/Pages/Packages.hs
@@ -6,6 +6,7 @@ where
 
 import Data.Foldable
 import Data.Function
+import Data.Map.Strict as Map
 import Data.Vector qualified as Vector
 import Distribution.Types.Version (Version)
 import Log (object, (.=))
@@ -165,7 +166,8 @@ showVersionDependenciesHandler namespace packageName version = do
       [ "duration" .= duration
       , "package" .= (display namespace <> "/" <> display packageName)
       , "release_id" .= release.releaseId
-      , "dependencies_count" .= Vector.length releaseDependencies
+      , "component_count" .= Map.size releaseDependencies
+      , "dependencies_count" .= Map.foldl' (\acc ds -> acc + Vector.length ds) 0 releaseDependencies
       ]
 
   render templateEnv $

--- a/src/web/FloraWeb/Templates/Packages.hs
+++ b/src/web/FloraWeb/Templates/Packages.hs
@@ -16,6 +16,7 @@ module FloraWeb.Templates.Packages
   ) where
 
 import Control.Monad (when)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text.Display
 import Data.Time (defaultTimeLocale)
@@ -51,11 +52,11 @@ showDependents namespace packageName title count packagesInfo currentPage =
       when (count > 30) $
         paginationNav count currentPage (DependentsOf namespace packageName)
 
-showDependencies :: Text -> Vector DependencyInfo -> FloraHTML
-showDependencies searchString requirementsInfo =
+showDependencies :: Text -> ComponentDependencies -> FloraHTML
+showDependencies searchString componentsInfo =
   div_ [class_ "container"] $! do
-    presentationHeader searchString "" (fromIntegral $! Vector.length requirementsInfo)
-    div_ [class_ ""] $! requirementListing requirementsInfo
+    presentationHeader searchString "" (fromIntegral $! Map.size componentsInfo)
+    div_ [class_ ""] . ul_ [class_ "component-list"] $! requirementListing componentsInfo
 
 listVersions :: Namespace -> PackageName -> Vector Release -> FloraHTML
 listVersions namespace packageName releases =
@@ -96,8 +97,8 @@ packageListing packages =
           packageListItem (namespace, name, synopsis, version, license)
       )
 
-requirementListing :: Vector DependencyInfo -> FloraHTML
-requirementListing requirements = ul_ [class_ "package-list"] $! Vector.forM_ requirements requirementListItem
+requirementListing :: ComponentDependencies -> FloraHTML
+requirementListing requirements = ul_ [class_ "component-list"] $! requirementListItem requirements
 
 showChangelog :: Namespace -> PackageName -> Version -> Maybe TextHtml -> FloraHTML
 showChangelog namespace packageName version mChangelog = do

--- a/src/web/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/web/FloraWeb/Templates/Pages/Packages.hs
@@ -223,12 +223,10 @@ displayDependencies
 displayDependencies (namespace, packageName, version) numberOfDependencies dependencies =
   li_ [class_ ""] $! do
     h3_ [class_ "package-body-section"] (toHtml $! "Dependencies (" <> display numberOfDependencies <> ")")
-    ul_ [class_ "dependencies"] $! do
-      let deps = foldMap renderDependency dependencies
-      let numberOfShownDependencies = fromIntegral @Int @Word (Vector.length dependencies)
-      if numberOfShownDependencies >= numberOfDependencies
-        then deps
-        else deps <> showAll Dependencies (Just version) namespace packageName
+    let deps = foldMap renderDependency dependencies
+    ul_ [class_ "dependencies"] $!
+      deps
+        <> showAll Dependencies (Just version) namespace packageName
 
 showAll :: Target -> Maybe Version -> Namespace -> PackageName -> FloraHTML
 showAll target mVersion namespace packageName = do

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -1,5 +1,6 @@
 module Flora.PackageSpec where
 
+import Data.Map qualified as Map
 import Data.Maybe
 import Data.Set qualified as Set
 import Data.Vector qualified as Vector
@@ -81,7 +82,10 @@ testCabalDeps = do
         , PackageName "void"
         ]
     )
-    (Set.fromList $ (.name) <$> Vector.toList dependencies)
+    ( Set.fromList $
+        fmap (.name) . Vector.toList . fromJust $
+          Map.lookup (CanonicalComponent "Cabal" Library) dependencies
+    )
 
 testInsertContainers :: TestEff ()
 testInsertContainers = do


### PR DESCRIPTION
## Proposed 

Expands the dependencies page to list the dependencies of each components, using the HTML details tag.

Opening is as draft for now: the package page might want to be changed to always have a link to the full components dependencies page; probably want the number of each components dependencies in the summary tag; and one of the tests needs updating. I'm relatively inexperienced with HTML and CSS, so do say if there are better approaches for this!

Attached two screenshots for what it looks like so far.

![Screen Shot 2023-03-02 at 00 09 02](https://user-images.githubusercontent.com/26348112/222295973-96956d26-e68f-47b6-a451-19c74d14ae8e.png)
![Screen Shot 2023-03-02 at 00 02 35](https://user-images.githubusercontent.com/26348112/222295242-12ea557b-87d9-4e7f-9d13-866c8f9364f4.png)

## Contributor checklist

- [x] My PR is related to #142 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)