### PR TITLE
[FLORA-354] Make package listings denser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Only index versionless package pages ([#343](https://github.com/flora-pm/flora-server/pull/343))
 * Display deprecation information on the package page ([#344](https://github.com/flora-pm/flora-server/pull/344))
 * Display deprecation information for releases ([#347](https://github.com/flora-pm/flora-server/pull/347))
+* Make package listings denser ([#355](https://github.com/flora-pm/flora-server/pull/355))
 
 ## 1.0.9 -- 2023-01-06
 * Fix package title size in smaller screens ([#297](https://github.com/flora-pm/flora-server/pull/297))

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,22 +20,22 @@ body {
   color: var(--text-color);
 }
 
-details > summary {
+summary.package-component {
   cursor: pointer;
   font-size: 1.25rem;
   line-height: 1.25rem;
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
   padding-left: 1rem;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
-details summary > * {
+summary.package-component > * {
   display: inline;
 }
 
-details > summary:hover {
+summary.package-component:hover {
   background-color: var(--package-list-item-background-hover-color);
   border-radius: 6px;
 }
@@ -122,17 +122,15 @@ a {
 }
 
 .package-list-item {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
   list-style: none;
 
   a {
     display: block;
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
     padding-left: 1rem;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
     font-size: 1.25rem;
     line-height: 1.75rem;
   }

--- a/design/stories/package-list--item.stories.js
+++ b/design/stories/package-list--item.stories.js
@@ -1,6 +1,3 @@
  
 export default {
-  title: "Components/Package List"
-};
-
-export const PackageListItem = () => "<li class=\"package-list-item\"><a href=\"/packages/@haskell/base\" class><h4 class=\"package-list-item__name\"><strong class>@haskell/base</strong></h4><p class=\"package-list-item__synopsis\">Basic libraries</p><div class=\"package-list-item__version\">4.16.0.0</div></a></li>"
+  title: "Com

--- a/src/web/FloraWeb/Components/PackageListItem.hs
+++ b/src/web/FloraWeb/Components/PackageListItem.hs
@@ -47,7 +47,7 @@ requirementListItem allComponentDeps =
     open = if Map.size allComponentDeps == 1 then [open_ ""] else mempty
     componentTitle component componentDeps = do
       details_ open $! do
-        summary_ . h3_ [] $! do
+        summary_ [class_ "package-component"] . h3_ [] $! do
           strong_ [] . toHtml $! display component
           toHtml $ " (" <> display (Vector.length componentDeps) <> " dependencies)"
         traverse_ componentListItems componentDeps

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -41,7 +41,7 @@ spec _fixtures =
     , testThis "The \"haskell\" namespace has the correct number of packages" testCorrectNumberInHaskellNamespace
     , testThis "@haskell/bytestring has the correct number of dependents" testBytestringDependents
     , testThis "Packages are not shown as their own dependent" testNoSelfDependent
-    , testThis "Searching for `text` returns unique results by namespace/package name" testSearchResultUnicity
+    , testThis "Searching for `text` returns expected results by namespace/package name" testSearchResultText
     , testThis "@hackage/time has the correct number of components of each type" testTimeComponents
     , testThis "Packages get deprecated" testPackagesDeprecation
     , testThis "Get non-deprecated packages" testGetNonDeprecatedPackages
@@ -138,7 +138,7 @@ testBytestringDependents :: TestEff ()
 testBytestringDependents = do
   results <- Query.getAllPackageDependentsWithLatestVersion (Namespace "haskell") (PackageName "bytestring") 1
   assertEqual
-    20
+    21
     (Vector.length results)
 
 testNoSelfDependent :: TestEff ()
@@ -152,10 +152,11 @@ testNoSelfDependent = do
         , PackageName "hashable"
         , PackageName "jose"
         , PackageName "parsec"
+        , PackageName "pg-entity"
         , PackageName "relude"
         , PackageName "semigroups"
+        , PackageName "text-display"
         , PackageName "xml"
-        , PackageName "pg-entity"
         ]
     )
     resultSet
@@ -190,13 +191,13 @@ testTimeConditions = do
   assertEqual timeLibExpectedCondition timeLib.metadata.conditions
   assertEqual timeUnixTestExpectedCondition timeUnixTest.metadata.conditions
 
-testSearchResultUnicity :: TestEff ()
-testSearchResultUnicity = do
+testSearchResultText :: TestEff ()
+testSearchResultText = do
   text <- fromJust <$> Query.getPackageByNamespaceAndName (Namespace "haskell") (PackageName "text")
   releases <- Query.getNumberOfReleases (text ^. #packageId)
   assertEqual 2 releases
   results <- Query.searchPackage 1 "text"
-  assertEqual 1 (Vector.length results)
+  assertEqual 2 (Vector.length results)
   assertEqual (Cabal.mkVersion [2, 0]) ((.version) $ Vector.head results)
 
 testPackagesDeprecation :: TestEff ()
@@ -222,7 +223,7 @@ testGetNonDeprecatedPackages = do
 testReleaseDeprecation :: TestEff ()
 testReleaseDeprecation = do
   result <- Query.getPackagesWithoutReleaseDeprecationInformation
-  assertEqual 62 (length result)
+  assertEqual 63 (length result)
 
   binary <- fromJust <$> Query.getPackageByNamespaceAndName (Namespace "haskell") (PackageName "binary")
   Just deprecatedBinaryVersion' <- Query.getReleaseByVersion (binary.packageId) (mkVersion [0, 10, 0, 0])

--- a/test/fixtures/Cabal/text-display.cabal
+++ b/test/fixtures/Cabal/text-display.cabal
@@ -1,0 +1,99 @@
+cabal-version:      3.0
+name:               text-display
+version:            0.0.4.0
+x-revision: 1
+category:           Text
+synopsis:           A typeclass for user-facing output
+description:
+  The 'Display' typeclass provides a solution for user-facing output that does not have to abide by the rules of the Show typeclass.
+
+homepage:           https://hackage.haskell.org/package/text-display/docs/doc/book/Introduction.html
+bug-reports:        https://github.com/haskell-text/text-display/issues
+author:             Hécate Moonlight
+maintainer:         Hécate Moonlight
+license:            MIT
+build-type:         Simple
+tested-with: GHC == {8.8.4, 8.10.7, 9.0.2, 9.2.7, 9.4.4, 9.6.1}
+
+extra-source-files:
+  LICENSE
+  README.md
+
+extra-doc-files:
+  ./doc/book/*.css
+  ./doc/book/*.html
+  ./doc/book/*.js
+  ./doc/book/css/*.css
+  ./doc/book/favicon.png
+  ./doc/book/favicon.svg
+  ./doc/book/FontAwesome/css/font-awesome.css
+  ./doc/book/FontAwesome/fonts/fontawesome-webfont.woff2
+  ./doc/book/fonts/*.css
+  ./doc/book/fonts/*.woff2
+  ./doc/book/searchindex.json
+  CHANGELOG.md
+
+flag book
+  description: Enable the generation of the book
+  default:     False
+  manual:      True
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell-text/text-display
+
+common common-extensions
+  default-language: Haskell2010
+
+common common-ghc-options
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -fhide-source-paths -Wno-unused-do-bind -funbox-strict-fields
+    -Wunused-packages
+
+common common-rts-options
+  ghc-options: -rtsopts -threaded -with-rtsopts=-N
+
+library
+  import:          common-extensions
+  import:          common-ghc-options
+  hs-source-dirs:  src
+  exposed-modules: Data.Text.Display
+  build-depends:
+    , base        >=4.12 && <5.0
+    , bytestring  >=0.10 && <0.12
+    , text        >=2.0
+
+executable book
+  import:         common-extensions
+  import:         common-ghc-options
+  import:         common-rts-options
+  main-is:        Main.hs
+  hs-source-dirs: doc/src
+
+  if !flag(book)
+    buildable: False
+
+  build-depends:
+    , base
+    , directory
+    , literatex
+    , shake
+
+test-suite text-display-test
+  import:         common-extensions
+  import:         common-ghc-options
+  import:         common-rts-options
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
+  hs-source-dirs: test
+  build-depends:
+    , base
+    , deepseq
+    , quickcheck-text
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , text-display


### PR DESCRIPTION
## Proposed changes

This PR reduces the space between packages in package listings. This allows us to use space more efficiently and make people scroll less.

## Contributor checklist

- [x] My PR closes #354 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
