### PR TITLE
[NO-ISSUE] Fix flake url for `horizon-platform`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,38 +82,39 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "get-flake": "get-flake",
-        "horizon-platform": "horizon-platform_2",
+        "horizon-shell-flake": "horizon-shell-flake",
         "lint-utils": "lint-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1678374258,
-        "narHash": "sha256-TwU2WXuZPVZeWm5pEeZJAUO0AzruD2BNAfAGW4pCK1c=",
+        "lastModified": 1680415413,
+        "narHash": "sha256-wwozvhvXFf4OVBC08A3JfR++/s7Q53RAyjH+OCuMWaU=",
         "ref": "refs/heads/master",
-        "rev": "dd6f40a5f8ecc611a4c7fad39835fe594ce5a2f1",
-        "revCount": 979,
+        "rev": "a4ece36e1a2de7e35fa02ae3254504c71a1d4643",
+        "revCount": 1062,
         "type": "git",
-        "url": "https://gitlab.homotopic.tech/horizon/horizon-platform"
+        "url": "https://gitlab.horizon-haskell.net/package-sets/horizon-platform"
       },
       "original": {
         "type": "git",
-        "url": "https://gitlab.homotopic.tech/horizon/horizon-platform"
+        "url": "https://gitlab.horizon-haskell.net/package-sets/horizon-platform"
       }
     },
-    "horizon-platform_2": {
+    "horizon-shell-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1677263150,
-        "narHash": "sha256-VS8RQKojTgHgPQQeL9WBIdS2C3nMZ1s7tL1slvm1qfA=",
-        "ref": "refs/heads/master",
-        "rev": "2e6a2ea4546bf344f1b7d671d3006e0cc6be1ca1",
-        "revCount": 947,
+        "lastModified": 1679524452,
+        "narHash": "sha256-xzNxvLVa3o0F/z4CnBDORv2Y6PfxjlGv7b7LybIyCSg=",
+        "ref": "refs/tags/0.0.8",
+        "rev": "21b8913803cefeb287bb244c7ee335638233db7f",
+        "revCount": 21,
         "type": "git",
-        "url": "https://gitlab.homotopic.tech/horizon/horizon-platform"
+        "url": "https://gitlab.horizon-haskell.net/shells/horizon-shell"
       },
       "original": {
+        "ref": "refs/tags/0.0.8",
         "type": "git",
-        "url": "https://gitlab.homotopic.tech/horizon/horizon-platform"
+        "url": "https://gitlab.horizon-haskell.net/shells/horizon-shell"
       }
     },
     "lint-utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     flake-utils = { url = "github:numtide/flake-utils"; };
     horizon-platform = {
-      url = "git+https://gitlab.homotopic.tech/horizon/horizon-platform";
+      url = "git+https://gitlab.horizon-haskell.net/package-sets/horizon-platform";
     };
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     streamly.url = "git+https://github.com/composewell/streamly";


### PR DESCRIPTION
The GitLab instance seems to have moved, leading to the `nix` commands failing. Or it's just temporarily down, but on https://horizon-haskell.net/ there's a new link that "just works".

## Proposed changes

Change the flake url to the new one, which is https://gitlab.horizon-haskell.net/package-sets/horizon-platform.

@locallycompact I just wanted to check out the repo and try something, and stumbled over this. You would probably know if this PR makes sense, that is, if that new url is correct as "the new home" for `horizon-platform`.

Note that I didn't use the same commit, but rather the latest one. I could of course change that, but everything seems to work just fine. Just let me know :)

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
