### PR TITLE
[NO-ISSUE] Re-add tooling to Nix `devShell`, "repairing" the `make build` command

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,6 +170,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1673947312,
@@ -241,6 +257,7 @@
         "flake-utils": "flake-utils",
         "horizon-platform": "horizon-platform",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable",
         "poolboy": "poolboy",
         "streamly": "streamly"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -225,15 +225,15 @@
       "locked": {
         "lastModified": 1680368030,
         "narHash": "sha256-3MY2l3Niwno7ZmiRAoSUjocQvTWzJ5VdmspXZFF5FDc=",
-        "ref": "refs/heads/master",
+        "owner": "blackheaven",
+        "repo": "poolboy",
         "rev": "dadf6504bc5c8c50ba6a8cf387eb4974e055f533",
-        "revCount": 11,
-        "type": "git",
-        "url": "https://github.com/blackheaven/poolboy"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://github.com/blackheaven/poolboy"
+        "owner": "blackheaven",
+        "repo": "poolboy",
+        "type": "github"
       }
     },
     "root": {
@@ -250,15 +250,15 @@
       "locked": {
         "lastModified": 1679066570,
         "narHash": "sha256-mMZi6Uo0bA+fERInii28Ok2ZvzSmQH2XPQ76gBZJRD4=",
-        "ref": "refs/heads/master",
+        "owner": "composewell",
+        "repo": "streamly",
         "rev": "7e80fa90885745f1ff2711c8b153cd262af148a1",
-        "revCount": 3989,
-        "type": "git",
-        "url": "https://github.com/composewell/streamly"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://github.com/composewell/streamly"
+        "owner": "composewell",
+        "repo": "streamly",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,53 +3,52 @@
   inputs = {
     flake-utils = { url = "github:numtide/flake-utils"; };
     horizon-platform = {
-      url = "git+https://gitlab.horizon-haskell.net/package-sets/horizon-platform";
+      url =
+        "git+https://gitlab.horizon-haskell.net/package-sets/horizon-platform";
     };
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     streamly.url = "git+https://github.com/composewell/streamly";
     streamly.flake = false;
     poolboy.url = "git+https://github.com/blackheaven/poolboy";
   };
-  outputs =
-    inputs@{ self, flake-utils, horizon-platform, nixpkgs, ... }:
+  outputs = inputs@{ self, flake-utils, horizon-platform, nixpkgs, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
-    let
-      pkgs = import nixpkgs { inherit system; };
-      hsPkgs = with pkgs.haskell.lib;
-        horizon-platform.legacyPackages.${system}.override {
-          overrides = hfinal: hprev: rec {
-            flora = overrideCabal
-              (dontHaddock (dontCheck
-                (doJailbreak (hfinal.callCabal2nix "flora" ./. { }))))
-              (drv: {
-                preConfigure = ''
-                  cd cbits; ${pkgs.souffle}/bin/souffle -g categorise.{cpp,dl}
-                  cd ..
-                '';
-              });
-            streamly-core = hfinal.callCabal2nix "streamly-core" "${inputs.streamly}/core/" { };
-            streamly = hfinal.callCabal2nix "streamly" inputs.streamly { };
-            poolboy = hfinal.callCabal2nix "poolboy" inputs.poolboy { };
+      let
+        pkgs = import nixpkgs { inherit system; };
+        hsPkgs = with pkgs.haskell.lib;
+          horizon-platform.legacyPackages.${system}.override {
+            overrides = hfinal: hprev: rec {
+              flora = overrideCabal (dontHaddock (dontCheck
+                (doJailbreak (hfinal.callCabal2nix "flora" ./. { })))) (drv: {
+                  preConfigure = ''
+                    cd cbits; ${pkgs.souffle}/bin/souffle -g categorise.{cpp,dl}
+                    cd ..
+                  '';
+                });
+              streamly-core =
+                hfinal.callCabal2nix "streamly-core" "${inputs.streamly}/core/"
+                { };
+              streamly = hfinal.callCabal2nix "streamly" inputs.streamly { };
+              poolboy = hfinal.callCabal2nix "poolboy" inputs.poolboy { };
+            };
+          };
+      in {
+        apps = rec {
+          default = server;
+
+          server = {
+            type = "app";
+
+            program = "${hsPkgs.flora}/bin/flora-server";
+          };
+
+          cli = {
+            type = "app";
+
+            program = "${hsPkgs.flora}/bin/flora-cli";
           };
         };
-    in
-    {
-      apps = rec {
-        default = server;
-
-        server = {
-          type = "app";
-
-          program = "${hsPkgs.flora}/bin/flora-server";
-        };
-
-        cli = {
-          type = "app";
-
-          program = "${hsPkgs.flora}/bin/flora-cli";
-        };
-      };
-      devShells.default = hsPkgs.flora.env;
-      packages.default = hsPkgs.flora;
-    });
+        devShells.default = hsPkgs.flora.env;
+        packages.default = hsPkgs.flora;
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,15 @@
 {
   description = "flora";
   inputs = {
-    flake-utils = { url = "github:numtide/flake-utils"; };
-    horizon-platform = {
-      url =
-        "git+https://gitlab.horizon-haskell.net/package-sets/horizon-platform";
-    };
+    flake-utils.url = "github:numtide/flake-utils";
+    horizon-platform.url =
+      "git+https://gitlab.horizon-haskell.net/package-sets/horizon-platform";
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    streamly.url = "git+https://github.com/composewell/streamly";
-    streamly.flake = false;
-    poolboy.url = "git+https://github.com/blackheaven/poolboy";
+    streamly = {
+      url = "github:composewell/streamly";
+      flake = false;
+    };
+    poolboy.url = "github:blackheaven/poolboy";
   };
   outputs = inputs@{ self, flake-utils, horizon-platform, nixpkgs, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
@@ -17,7 +17,7 @@
         pkgs = import nixpkgs { inherit system; };
         hsPkgs = with pkgs.haskell.lib;
           horizon-platform.legacyPackages.${system}.override {
-            overrides = hfinal: hprev: rec {
+            overrides = hfinal: hprev: {
               flora = overrideCabal (dontHaddock (dontCheck
                 (doJailbreak (hfinal.callCabal2nix "flora" ./. { })))) (drv: {
                   preConfigure = ''
@@ -38,13 +38,11 @@
 
           server = {
             type = "app";
-
             program = "${hsPkgs.flora}/bin/flora-server";
           };
 
           cli = {
             type = "app";
-
             program = "${hsPkgs.flora}/bin/flora-cli";
           };
         };


### PR DESCRIPTION
## Proposed changes

After cleaning up the `flake.nix` a tiny bit (feel free to squash if you don't like the fine-grained commits), I've tried "resurrecting" the Nix development environment, or rather, begun working on that.

The `nix-shell` or `nix develop` environment in its previous state did not contain any tooling, but has done so at some point in the past. Just putting some of the tools needed to build the application in there didn't work immediately, as I ran into the `souffle` 2.2 vs 2.3 issue, so I've worked around that. I also re-added the nice welcome message to the shell :)

**Notes:**
- I've probably not added all the tools needed to do *everything*, but this set of packages unbreaks the `make build` command, and adds some Haskell-specific tooling like `hlint`, `fourmolu`, and so on.
- The `nix build` does not work (yet), though I think it never did.
- The frozen versions of the Haskell packages are not really in sync with the ones in `nixpkgs`, as far as I can tell, so the ones that GHC "knows" in the Nix environment don't work with `flora`. I'm personally using the `nix develop`/`make nix-shell` to provide me the tooling, and let `cabal-install` handle the packages.

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
