### PR TITLE
[NO-ISSUE] Pin the `postgres` Docker image to version 14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - database
 
   database:
-    image: "postgres"
+    # Pinned postgres:14.7
+    image: "postgres@sha256:577d48a963bdd16e8b93e853aa830c78fc4622ebe9717bc95f6736d9aa5003e3"
     container_name: database
     ports:
       - "5432:5432"


### PR DESCRIPTION
I tried out the Docker setup, but it's using `postgres`, that is, `postgres:latest`, which downloads the database in major version 15. The readme still mentions that version 14 is used, so I pinned it.

## Proposed changes

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
