### PR TITLE
[FLORA-368] Upgrade and unbreak docker setup for GHC 9.4.4

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,8 +10,8 @@ pull_request_rules:
     name: Put pull requests in the rebase+merge queue
     conditions:
       - label=merge me
-      - 'check-success=Frontend Tests'
-      - 'check-success=Backend Tests'
+      - 'check-success=Frontend tests'
+      - 'check-success=Backend tests'
       # - '#approved-reviews-by>=1'
   # merge+squash strategy
   - actions:
@@ -24,8 +24,8 @@ pull_request_rules:
     name: Put pull requests in the squash+merge queue
     conditions:
       - label=squash+merge me
-      - 'check-success=Frontend Tests'
-      - 'check-success=Backend Tests'
+      - 'check-success=Frontend tests'
+      - 'check-success=Backend tests'
       # - '#approved-reviews-by>=1'
 
 queue_rules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,38 @@
-# syntax=docker/dockerfile:1
-FROM ubuntu:22.04
+# this is a pinned ubuntu:22.04 (newer versions have incomptible
+# library versions for souffle)
+FROM ubuntu@sha256:67211c14fa74f070d27cc59d69a7fa9aeff8e28ea118ef3babc295a0428a6d21
+
+ARG ghc_version=9.4.4
+ARG cabal_version=3.10.1.0
 
 # generate a working directory
 WORKDIR /flora-server 
 
-RUN apt update
-RUN apt install -y build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 git
+RUN apt update && \
+    apt install -y build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 git
 RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 RUN echo 'export PATH="$PATH:/root/.ghcup/bin"' >> /etc/profile
 ENV PATH="$PATH:/root/.ghcup/bin"
-RUN ghcup install ghc 9.2.5 && ghcup set ghc 9.2.5 && ghcup install cabal
+RUN ghcup install ghc $ghc_version && \
+    ghcup set ghc $ghc_version && \
+    ghcup install cabal $cabal_version
 
-# install dependencies (pg_config, postgresql-client, postrgresql-migrations & yarn)
+# install dependencies (pg_config, postgresql-client, yarn)
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list 
 RUN apt install -y nodejs libpq-dev mcpp wget zsh tmux postgresql-client
 RUN corepack enable
-RUN cabal update
-RUN cabal install -j8 postgresql-migration
 
 # install soufflé
 RUN wget --content-disposition https://github.com/souffle-lang/souffle/releases/download/2.2/x86_64-ubuntu-2004-souffle-2.2-Linux.deb
 RUN apt install -f -y ./x86_64-ubuntu-2004-souffle-2.2-Linux.deb
+
+# install Haskell tooling (note that for cabal, it's probably better
+# to run `cabal update` as separate step, as cabal doesn't delete
+# package versions)
+RUN cabal update
+RUN cabal install -j8 postgresql-migration ghcid
 
 # configure the shell
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
@@ -30,10 +40,11 @@ COPY scripts/shell-welcome.txt /etc/motd
 COPY scripts/.zshrc /root/.zshrc
 
 # build Haskell dependencies
-COPY Makefile cabal.project flora.cabal ./
+COPY cabal.project flora.cabal ./
 RUN cabal build --only-dependencies -j
 
-# Compile Souffle source files
+# compile Souffle source files
+COPY Makefile ./
 COPY cbits ./cbits
 RUN make souffle
 
@@ -41,5 +52,6 @@ RUN make souffle
 COPY assets ./assets
 RUN make build-assets
 
+ENV PATH="$PATH:/root/.cabal/bin"
 RUN echo $PATH > /etc/profile
 CMD [ "/bin/sh", "-c", "sleep 1d"]

--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ nix-shell: ## Enter the Nix shell
 	@nix-shell
 
 docker-build: ## Build and start the container cluster
-	@docker-compose up -d --build
+	@docker compose up -d --build
 
 docker-start: ## Start the container cluster
-	@docker-compose up -d
+	@docker compose up -d
 
 docker-enter: ## Enter the docker environment
-	docker-compose exec flora-server "zsh"
+	docker compose exec flora-server "zsh"
 
 start-tmux: ## Start a Tmux session with hot code reloading
 	./scripts/start-tmux.sh

--- a/README.md
+++ b/README.md
@@ -85,17 +85,19 @@ and communicates with another container for the PostgreSQL database.
 ```bash
 # You need to build the container first. It's gonna take around 13 minutes the first time you build
 $ make docker-build
-# Start the container.
-$ make docker-start
 # Once the containers are running, you can enter the development environment and start hacking
 $ make docker-enter
+$ source environment.docker.sh
 # You'll be in the docker container. Environment variables are automatically set 
 # so you should be able to start Flora
 (docker)$ make start-tmux
 # You'll be in a tmux session, everything should be launched
 # Visit localhost:8084 from your web browser to see if it all works.
+```
 
-# To provision the development database, type:
+To provision the development database, type:
+
+```bash
 $ make docker-enter
 (docker)$ source environment.docker.sh
 (docker)$ make db-drop  # password is 'postgres' by default

--- a/environment.docker.sh
+++ b/environment.docker.sh
@@ -1,0 +1,6 @@
+source environment.sh
+
+export FLORA_DB_HOST="database"
+export FLORA_HTTP_PORT=8084
+export FLORA_DB_CONNSTRING="host=${FLORA_DB_HOST} dbname=${FLORA_DB_DATABASE}\
+  user=${FLORA_DB_USER} password=${FLORA_DB_PASSWORD}"

--- a/scripts/start-tmux.sh
+++ b/scripts/start-tmux.sh
@@ -8,6 +8,7 @@ sleep 1
 tmux send-keys -t "flora" 'make watch-server' 'C-m'
 tmux select-window -t flora:0
 sleep 1
+(cd assets && yarn install)
 tmux split-window -h 'make watch-assets'
 tmux send-keys -t "flora" 'C-b'
 tmux attach-session -t flora


### PR DESCRIPTION
## Proposed changes

I did the following and also added some minor improvements to the whole Docker setup:

1. Pinned the base image: indeed using Ubuntu 22.04 was necessary for `souffle` to work/build.
2. Introduced docker `ARGS` to hopefully make future GHC upgrades easier for this setup.
3. Updated `cabal-install`, as it was incompatible in the default version 3.6.*.
4. Added the missing `ghcid`.
5. Rearranged and merged some Docker commands for slightly better caching and robustness.
6. Added `environment.docker.sh` due to `FLORA_DB_HOST` having to be set differently in the docker compose setup.

Other things:
- I had to do `yarn install` in the `start-tmux.sh` script, or otherwise the `make start-tmux` would crash with missing dependencies.
- Migrated from the deprecated, standalone `docker-compose` to the `docker compose` command.

I'd be glad if you could also quickly test if it works (though it takes quite a while to get up). But note: if you have local `dist-newstyle` or `node_modules` directories, those might lead to strange `git` behavior inside the docker container due to permissions. It works for me if I clean beforehand.

## Contributor checklist

- [x] My PR is related to #368
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
