### PR TITLE
[FLORA-219] Implement namespace browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.13 -- XXXX-XX-XX
 * Exclude deprecated releases from latest versions and search ([#373](https://github.com/flora-pm/flora-server/pull/373))
+* Add namespace browsing ([#375](https://github.com/flora-pm/flora-server/pull/375))
 
 ## 1.0.12 -- 2023-04-04
 

--- a/assets/css/package.css
+++ b/assets/css/package.css
@@ -18,14 +18,6 @@
   list-style-position: inside;
 }
 
-.package-title {
-  .version {
-    font-size: medium;
-    line-height: 1.3rem;
-    padding-left: 4px;
-  }
-}
-
 .synopsis {
   text-align: center;
   font-size: 1.25rem;
@@ -194,6 +186,18 @@
   .pagination-footer__next {
     border-bottom-right-radius: 0.5rem;
     border-top-right-radius: 0.5rem;
+  }
+}
+
+.package-title {
+  .version {
+    font-size: medium;
+    line-height: 1.3rem;
+    padding-left: 4px;
+  }
+
+  a:hover {
+    text-decoration: underline;
   }
 }
 

--- a/src/web/FloraWeb/Components/PaginationNav.hs
+++ b/src/web/FloraWeb/Components/PaginationNav.hs
@@ -42,7 +42,10 @@ paginationNav totalResults currentPage searchAction = do
               }
 
 mkURL :: SearchAction -> Word -> Text
-mkURL ListAllPackages pageNumber = "/" <> toUrlPiece (Links.packageIndexLink pageNumber)
+mkURL ListAllPackages pageNumber =
+  "/" <> toUrlPiece (Links.packageIndexLink pageNumber)
+mkURL (ListAllPackagesInNamespace namespace) pageNumber =
+  "/" <> toUrlPiece (Links.namespaceLink namespace pageNumber)
 mkURL (SearchPackages searchTerm) pageNumber =
   "/" <> toUrlPiece (Links.packageSearchLink searchTerm pageNumber)
 mkURL (DependentsOf namespace packageName) pageNumber =

--- a/src/web/FloraWeb/Links.hs
+++ b/src/web/FloraWeb/Links.hs
@@ -19,7 +19,7 @@ packageLink :: Namespace -> PackageName -> Link
 packageLink namespace packageName =
   links
     // Web.packages
-    // Web.show
+    // Web.showPackage
     /: namespace
     /: packageName
 

--- a/src/web/FloraWeb/Links.hs
+++ b/src/web/FloraWeb/Links.hs
@@ -15,6 +15,14 @@ import Servant.Links qualified as Links
 links :: Pages.Routes' (Links.AsLink Link)
 links = Links.allFieldLinks
 
+namespaceLink :: Namespace -> Word -> Link
+namespaceLink namespace pageNumber =
+  links
+    // Web.packages
+    // Web.showNamespace
+    /: namespace
+    /: Just pageNumber
+
 packageLink :: Namespace -> PackageName -> Link
 packageLink namespace packageName =
   links

--- a/src/web/FloraWeb/Routes/Pages/Packages.hs
+++ b/src/web/FloraWeb/Routes/Pages/Packages.hs
@@ -18,7 +18,12 @@ data Routes' mode = Routes'
       :: mode
         :- QueryParam "page" Word
           :> Get '[HTML] (Html ())
-  , show
+  , showNamespace
+      :: mode
+        :- Capture "namespace" Namespace
+          :> QueryParam "page" Word
+          :> Get '[HTML] (Html ())
+  , showPackage
       :: mode
         :- Capture "namespace" Namespace
           :> Capture "package" PackageName

--- a/src/web/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/web/FloraWeb/Templates/Pages/Packages.hs
@@ -89,7 +89,7 @@ presentationHeader release namespace name synopsis =
   div_ [class_ "divider"] $! do
     div_ [class_ "page-title"] $
       h1_ [class_ "package-title"] $! do
-        span_ [class_ "headline"] $! toHtml (display namespace) <> "/" <> toHtml name
+        span_ [class_ "headline"] $! displayNamespace namespace <> "/" <> toHtml name
         span_ [class_ "version"] $! displayReleaseVersion release.version
     div_ [class_ "synopsis"] $
       p_ [class_ ""] (toHtml synopsis)
@@ -156,6 +156,12 @@ renderDescription input = renderHaddock input
 
 displayReleaseVersion :: Version -> FloraHTML
 displayReleaseVersion = toHtml
+
+displayNamespace :: Namespace -> FloraHTML
+displayNamespace namespace =
+  a_
+    [class_ "", href_ ("/" <> toUrlPiece (Links.namespaceLink namespace 1))]
+    (toHtml $! display namespace)
 
 displayLicense :: SPDX.License -> FloraHTML
 displayLicense license =

--- a/src/web/FloraWeb/Templates/Pages/Search.hs
+++ b/src/web/FloraWeb/Templates/Pages/Search.hs
@@ -2,11 +2,12 @@ module FloraWeb.Templates.Pages.Search where
 
 import Control.Monad (when)
 import Data.Text (Text)
+import Data.Text.Display (display)
 import Data.Vector (Vector)
 import Lucid
 
 import Data.Maybe (fromJust, isJust)
-import Flora.Model.Package (PackageInfo (..))
+import Flora.Model.Package (Namespace, PackageInfo (..))
 import Flora.Search (SearchAction (..))
 import FloraWeb.Components.PackageListHeader (presentationHeader)
 import FloraWeb.Components.PackageListItem
@@ -20,6 +21,14 @@ showAllPackages count currentPage packagesInfo = do
     presentationHeader "Packages" "" count
     div_ [class_ ""] $! packageListing packagesInfo
     paginationNav count currentPage ListAllPackages
+
+showAllPackagesInNamespace :: Namespace -> Word -> Word -> Vector PackageInfo -> FloraHTML
+showAllPackagesInNamespace namespace count currentPage packagesInfo = do
+  div_ [class_ "container"] $! do
+    let title = "Packages in " <> display namespace
+    presentationHeader title "" count
+    div_ [class_ ""] $! packageListing packagesInfo
+    paginationNav count currentPage (ListAllPackagesInNamespace namespace)
 
 showResults :: Text -> Word -> Word -> Maybe PackageInfo -> Vector PackageInfo -> FloraHTML
 showResults searchString count currentPage mExactMatch results = do

--- a/test/Flora/TemplateSpec.hs
+++ b/test/Flora/TemplateSpec.hs
@@ -12,6 +12,7 @@ spec =
   testThese
     "templates"
     [ testThis "Generate a link to a package + version" testGenerateVersionedPackageLink
+    , testThis "Generate a link to a namespace" testGenerateNamespaceLink
     ]
 
 testGenerateVersionedPackageLink :: TestEff ()
@@ -21,3 +22,9 @@ testGenerateVersionedPackageLink = do
   let version = Version.mkVersion [4, 16, 1, 0]
   let generatedLink = toUrlPiece $ Links.packageVersionLink namespace packageName version
   assertEqual "packages/%40hackage/base/4.16.1.0" generatedLink
+
+testGenerateNamespaceLink :: TestEff ()
+testGenerateNamespaceLink = do
+  let namespace = Namespace "haskell"
+  let generatedLink = toUrlPiece $ Links.namespaceLink namespace 2
+  assertEqual "packages/%40haskell?page=2" generatedLink


### PR DESCRIPTION
## Proposed changes

As described in #219. I also added a link to the namespace in the package title; don't know if you want/like that, but I didn't know about `Servant.Links` before and wanted to try it out.

I have some remaining questions though:

1. Some `count*` functions in `Query.hs` filter for the `fully-imported` status, some don't. I wasn't sure which to pick, so left it out for now.
2. The new `showNamespaceHandler` is *very* similar to the `indexHandler` above, but I felt like "repeating" some easy steps or function is a deliberate choice when looking at some other code. Plus, extracting a function here would most likely mean having an `Eff` action as argument, which would require importing lots of stuff and IME not really make anything more flexible. How do you think about this?
3. `listAllPackagesInNamespaces` does not log, like `listAllPackages`. But maybe both should?
4. I'm not sure if I used `Flora.Search.SearchAction` the right way.

## Contributor checklist

- [x] My PR is related to #219 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
