### PR TITLE
Implement working search bar in reverse dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Exclude deprecated releases from latest versions and search ([#373](https://github.com/flora-pm/flora-server/pull/373))
 * Add namespace browsing ([#375](https://github.com/flora-pm/flora-server/pull/375))
 * Overhaul the `nix` setup of flora and adjust the docs accordingly ([#369](https://github.com/flora-pm/flora-server/pull/369))
+* Add search bar for reverse dependencies ([#389](https://github.com/flora-pm/flora-server/pull/389))
 
 ## 1.0.12 -- 2023-04-04
 

--- a/src/core/Flora/Search.hs
+++ b/src/core/Flora/Search.hs
@@ -21,14 +21,19 @@ data SearchAction
   = ListAllPackages
   | ListAllPackagesInNamespace Namespace
   | SearchPackages Text
-  | DependentsOf Namespace PackageName
+  | DependentsOf Namespace PackageName (Maybe Text)
   deriving (Eq, Ord, Show)
 
 instance Display SearchAction where
   displayBuilder ListAllPackages = "Packages"
   displayBuilder (ListAllPackagesInNamespace namespace) = "Packages in " <> displayBuilder namespace
   displayBuilder (SearchPackages title) = "\"" <> Builder.fromText title <> "\""
-  displayBuilder (DependentsOf namespace packageName) = "Dependents of " <> displayBuilder namespace <> "/" <> displayBuilder packageName
+  displayBuilder (DependentsOf namespace packageName mbSearchString) =
+    "Dependents of "
+      <> displayBuilder namespace
+      <> "/"
+      <> displayBuilder packageName
+      <> foldMap (\searchString -> " \"" <> Builder.fromText searchString <> "\"") mbSearchString
 
 searchPackageByName :: (DB :> es, Log :> es, Time :> es) => Word -> Text -> Eff es (Word, Vector PackageInfo)
 searchPackageByName pageNumber queryString = do

--- a/src/web/FloraWeb/Components/PaginationNav.hs
+++ b/src/web/FloraWeb/Components/PaginationNav.hs
@@ -48,8 +48,8 @@ mkURL (ListAllPackagesInNamespace namespace) pageNumber =
   "/" <> toUrlPiece (Links.namespaceLink namespace pageNumber)
 mkURL (SearchPackages searchTerm) pageNumber =
   "/" <> toUrlPiece (Links.packageSearchLink searchTerm pageNumber)
-mkURL (DependentsOf namespace packageName) pageNumber =
-  "/" <> toUrlPiece (Links.packageDependents namespace packageName pageNumber)
+mkURL (DependentsOf namespace packageName mbSearchString) pageNumber =
+  "/" <> toUrlPiece (Links.packageDependents namespace packageName pageNumber mbSearchString)
 
 paginate
   :: Word

--- a/src/web/FloraWeb/Components/Utils.hs
+++ b/src/web/FloraWeb/Components/Utils.hs
@@ -2,8 +2,18 @@ module FloraWeb.Components.Utils where
 
 import Data.Text (Text)
 import FloraWeb.Templates.Types (FloraHTML)
-import Lucid (Attribute, a_, class_, href_, role_, toHtml)
+import Lucid
 import Lucid.Base (makeAttribute)
+import Lucid.Svg
+  ( d_
+  , fill_
+  , path_
+  , stroke_
+  , stroke_linecap_
+  , stroke_linejoin_
+  , stroke_width_
+  , viewBox_
+  )
 
 text :: Text -> FloraHTML
 text = toHtml
@@ -43,3 +53,28 @@ xId_ = makeAttribute "x-id"
 
 id'_ :: Text -> Attribute
 id'_ = makeAttribute ":id"
+
+data SearchBarOptions = SearchBarOptions
+  { actionUrl :: Text
+  , placeholder :: Text
+  }
+
+searchBar :: SearchBarOptions -> FloraHTML
+searchBar SearchBarOptions{actionUrl, placeholder} =
+  form_ [action_ actionUrl, method_ "GET"] $! do
+    div_ [class_ "main-search"] $! do
+      label_ [for_ "search"] ""
+      input_
+        [ class_
+            "search-bar"
+        , type_ "search"
+        , id_ "search"
+        , name_ "q"
+        , placeholder_ placeholder
+        , value_ ""
+        , tabindex_ "1"
+        , autofocus_
+        ]
+      button_ [type_ "submit"] $
+        svg_ [xmlns_ "http://www.w3.org/2000/svg", style_ "color: gray", fill_ "none", viewBox_ "0 0 24 24", stroke_ "currentColor"] $
+          path_ [stroke_linecap_ "round", stroke_linejoin_ "round", stroke_width_ "2", d_ "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"]

--- a/src/web/FloraWeb/Links.hs
+++ b/src/web/FloraWeb/Links.hs
@@ -81,14 +81,15 @@ packageDependencies namespace packageName version =
     /: packageName
     /: version
 
-packageDependents :: Namespace -> PackageName -> Word -> Link
-packageDependents namespace packageName pageNumber =
+packageDependents :: Namespace -> PackageName -> Word -> Maybe Text -> Link
+packageDependents namespace packageName pageNumber mbSearchString =
   links
     // Web.packages
     // Web.showDependents
     /: namespace
     /: packageName
     /: Just pageNumber
+    /: mbSearchString
 
 packageVersions :: Namespace -> PackageName -> Link
 packageVersions namespace packageName =

--- a/src/web/FloraWeb/Routes/Pages/Packages.hs
+++ b/src/web/FloraWeb/Routes/Pages/Packages.hs
@@ -4,6 +4,7 @@ module FloraWeb.Routes.Pages.Packages
   )
 where
 
+import Data.Text (Text)
 import Distribution.Types.Version (Version)
 import Flora.Model.Package (Namespace, PackageName)
 import Lucid
@@ -34,6 +35,7 @@ data Routes' mode = Routes'
           :> Capture "package" PackageName
           :> "dependents"
           :> QueryParam "page" Word
+          :> QueryParam "q" Text
           :> Get '[HTML] (Html ())
   , showDependencies
       :: mode

--- a/src/web/FloraWeb/Templates/Packages.hs
+++ b/src/web/FloraWeb/Templates/Packages.hs
@@ -35,14 +35,17 @@ import Flora.Search (SearchAction (..))
 import FloraWeb.Components.PackageListHeader (presentationHeader)
 import FloraWeb.Components.PackageListItem (licenseIcon, packageListItem, requirementListItem)
 import FloraWeb.Components.PaginationNav (paginationNav)
+import FloraWeb.Components.Utils
 import FloraWeb.Components.VersionListHeader qualified as Template
 import FloraWeb.Templates
 
-showDependents :: Namespace -> PackageName -> Text -> Word -> Vector DependencyInfo -> Word -> FloraHTML
-showDependents namespace packageName title count packagesInfo currentPage =
+showDependents :: Namespace -> PackageName -> Word -> Vector DependencyInfo -> Word -> FloraHTML
+showDependents namespace packageName count packagesInfo currentPage = do
+  let title = "Dependents of " <> display namespace <> "/" <> display packageName
   div_ [class_ "container"] $! do
     presentationHeader title "" count
     div_ [class_ ""] $! do
+      searchBar (SearchBarOptions{actionUrl = "", placeholder = ""})
       ul_ [class_ "package-list"] $!
         Vector.forM_
           packagesInfo
@@ -50,7 +53,7 @@ showDependents namespace packageName title count packagesInfo currentPage =
               packageListItem (dep.namespace, dep.name, dep.latestSynopsis, dep.latestVersion, dep.latestLicense)
           )
       when (count > 30) $
-        paginationNav count currentPage (DependentsOf namespace packageName)
+        paginationNav count currentPage (DependentsOf namespace packageName Nothing)
 
 showDependencies :: Text -> ComponentDependencies -> FloraHTML
 showDependencies searchString componentsInfo = do

--- a/src/web/FloraWeb/Templates/Pages/Home.hs
+++ b/src/web/FloraWeb/Templates/Pages/Home.hs
@@ -6,25 +6,16 @@ import CMarkGFM
 import Control.Monad.Reader
 import Data.Text (Text)
 import Lucid
-import Lucid.Svg
-  ( d_
-  , fill_
-  , path_
-  , stroke_
-  , stroke_linecap_
-  , stroke_linejoin_
-  , stroke_width_
-  , viewBox_
-  )
 import PyF
 
 import Flora.Environment
+import FloraWeb.Components.Utils (SearchBarOptions (..), searchBar)
 import FloraWeb.Templates.Types
 
 show :: FloraHTML
 show = do
   banner
-  searchBar
+  searchBar (SearchBarOptions{actionUrl = "/search", placeholder = "Find a package"})
   buttons
 
 about :: FloraHTML
@@ -76,26 +67,6 @@ banner = do
   div_ [class_ "relative"] $
     h1_ [class_ "main-title"] $
       span_ [class_ "main-title"] "Search Haskell packages on Flora"
-
-searchBar :: FloraHTML
-searchBar =
-  form_ [action_ "/search", method_ "GET"] $! do
-    div_ [class_ "main-search"] $! do
-      label_ [for_ "search"] ""
-      input_
-        [ class_
-            "search-bar"
-        , type_ "search"
-        , id_ "search"
-        , name_ "q"
-        , placeholder_ "Find a package"
-        , value_ ""
-        , tabindex_ "1"
-        , autofocus_
-        ]
-      button_ [type_ "submit"] $
-        svg_ [xmlns_ "http://www.w3.org/2000/svg", style_ "color: gray", fill_ "none", viewBox_ "0 0 24 24", stroke_ "currentColor"] $
-          path_ [stroke_linecap_ "round", stroke_linejoin_ "round", stroke_width_ "2", d_ "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"]
 
 buttons :: FloraHTML
 buttons =

--- a/src/web/FloraWeb/Templates/Pages/Packages.hs
+++ b/src/web/FloraWeb/Templates/Pages/Packages.hs
@@ -237,7 +237,7 @@ displayDependencies (namespace, packageName, version) numberOfDependencies depen
 showAll :: Target -> Maybe Version -> Namespace -> PackageName -> FloraHTML
 showAll target mVersion namespace packageName = do
   let resource = case target of
-        Dependents -> Links.packageDependents namespace packageName 1
+        Dependents -> Links.packageDependents namespace packageName 1 Nothing
         Dependencies -> Links.packageDependencies namespace packageName (fromJust mVersion)
         Versions -> Links.packageVersions namespace packageName
   a_ [class_ "dependency", href_ ("/" <> toUrlPiece resource)] "Show all…"

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -136,14 +136,14 @@ testCorrectNumberInHaskellNamespace = do
 
 testBytestringDependents :: TestEff ()
 testBytestringDependents = do
-  results <- Query.getAllPackageDependentsWithLatestVersion (Namespace "haskell") (PackageName "bytestring") 1
+  results <- Query.getAllPackageDependentsWithLatestVersion (Namespace "haskell") (PackageName "bytestring") Nothing 1
   assertEqual
     22
     (Vector.length results)
 
 testNoSelfDependent :: TestEff ()
 testNoSelfDependent = do
-  results <- Query.getAllPackageDependents (Namespace "haskell") (PackageName "text")
+  results <- Query.getAllPackageDependents (Namespace "haskell") (PackageName "text") Nothing
   let resultSet = Set.fromList . fmap (view #name) $ Vector.toList results
   assertEqual
     ( Set.fromList


### PR DESCRIPTION
## Proposed changes

Reverse dependency lists (a.k.a dependents) can get huge, e.g. for the lens library, which makes pagination impractical. This implements a search bar in the reverse dependencies page.

TODOS:
- [ ] There is definitely still some work to be done on styling the search bar to be a nicer size, but this is something I'd rather get feedback on.
- [ ] There's also some work to be done on cleaning up duplication in the SQL code, I'll make them once we're certain that the semantic behaviour as implemented now is what we want.

## Contributor checklist

- [X] My PR is related to https://github.com/flora-pm/flora-server/issues/388 
- [X] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
