### PR TITLE
[FLORA-198] Fix mismatching OpenSearch names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Overhaul the `nix` setup of flora and adjust the docs accordingly ([#369](https://github.com/flora-pm/flora-server/pull/369))
 * Allow importing from index tarballs and incremental importing ([#387](https://github.com/flora-pm/flora-server/pull/387))
 * Introduce a public API ([#415](https://github.com/flora-pm/flora-server/pull/415))
+* Fix mismatching OpenSearch names ([#427](https://github.com/flora-pm/flora-server/pull/427))
 
 ## 1.0.12 -- 2023-04-04
 

--- a/src/web/FloraWeb/Common/OpenSearch.hs
+++ b/src/web/FloraWeb/Common/OpenSearch.hs
@@ -19,7 +19,7 @@ openSearchHandler :: Monad m => m XML.Document
 openSearchHandler =
   pure $
     openSearchDocument "OpenSearchDescription" $ do
-      element "ShortName" $ content "Search on Flora"
+      element "ShortName" $ content "Flora"
       element "Description" $ content "Search on Flora"
       element "InputEncoding" $ content "UTF-8"
       elementA "Url" [("type", "text/html"), ("method", "get"), ("template", "https://flora.pm/search?q={searchTerms}&ref=opensearch")] empty

--- a/src/web/FloraWeb/Common/OpenSearch.hs
+++ b/src/web/FloraWeb/Common/OpenSearch.hs
@@ -19,7 +19,7 @@ openSearchHandler :: Monad m => m XML.Document
 openSearchHandler =
   pure $
     openSearchDocument "OpenSearchDescription" $ do
-      element "ShortName" $ content "Flora"
+      element "ShortName" $ content "Search on Flora"
       element "Description" $ content "Search on Flora"
       element "InputEncoding" $ content "UTF-8"
       elementA "Url" [("type", "text/html"), ("method", "get"), ("template", "https://flora.pm/search?q={searchTerms}&ref=opensearch")] empty

--- a/src/web/FloraWeb/Components/Header.hs
+++ b/src/web/FloraWeb/Components/Header.hs
@@ -58,7 +58,7 @@ header = do
         link_
           [ rel_ "search"
           , type_ "application/opensearchdescription+xml"
-          , title_ "Search on Flora"
+          , title_ "Flora"
           , href_ "/opensearch.xml"
           ]
         meta_ [name_ "description", content_ "A package repository for the Haskell ecosystem"]


### PR DESCRIPTION
## Proposed changes

Match the "ShortName" field in the OpenSearch XML file with the "title" property in the link to the OpenSearch XML document in the head element. This complies with [Mozilla's OpenSearch description format page](https://developer.mozilla.org/en-US/docs/Web/OpenSearch#autodiscovery_of_search_plugins) and results in the "add search engine" button disappearing as it should once Flora has been added.

Also, the OpenSearch description does not make any sense as it now matches the short name, whereas it should describe the search engine (Flora). As it is not relevant I've left it for now, but it should probably be changed to something more appropriate in the future.

## Contributor checklist

- [x] My PR is related to #198 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
