### PR TITLE
[FLORA-388] Reverse depenencies search bar

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,7 @@ pull_request_rules:
     conditions:
       - label=merge me
       - 'check-success=Frontend_tests'
-      - 'check-success=Backend_tests'
+      - 'check-success~=.*Backend_tests.*'
       # - '#approved-reviews-by>=1'
   # merge+squash strategy
   - actions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a page on namespaces in the documentation ([#451](https://github.com/flora-pm/flora-server/pull/451))
 * Add initial support for hosting package tarballs ([#452](https://github.com/flora-pm/flora-server/pull/452))
 * Show depended on components in dependencies page ([#464](https://github.com/flora-pm/flora-server/pull/464))
+* Add search bar for reverse dependencies ([#476](https://github.com/flora-pm/flora-server/pull/476))
 
 ## 1.0.13 -- 2023-09-17
 * Exclude deprecated releases from latest versions and search ([#373](https://github.com/flora-pm/flora-server/pull/373))

--- a/assets/css/2-components/5-primary-search.css
+++ b/assets/css/2-components/5-primary-search.css
@@ -1,0 +1,61 @@
+/* stylelint-disable selector-class-pattern */
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
+
+.main-search {
+  background-color: var(--search-bar-background-color);
+  border-radius: 0.75rem;
+  border-width: 2px;
+  display: flex;
+  font-size: 1.5rem;
+  justify-content: center;
+  line-height: 2rem;
+  max-width: 28rem;
+  outline-offset: -2px;
+  overflow: hidden;
+  padding: 0.5rem;
+
+  .search-bar {
+    background-color: var(--search-bar-background-color);
+    color: var(--search-bar-color);
+    display: block;
+    margin-left: 0.5rem;
+    font-size: 1.5rem;
+    line-height: 2rem;
+    padding: 0.5rem;
+    flex-grow: 1;
+    min-width: 0;
+  }
+
+  .search-bar:hover {
+    background-color: var(--search-bar-background-hover-color);
+  }
+
+  .search-bar:focus {
+    background-color: var(--search-bar-background-focus-color);
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+}
+
+.main-search:focus-within {
+  border-color: var(--search-bar-focus-border-color);
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 400ms;
+
+  /* offset-x | offset-y | blur-radius | spread-radius | color */
+  box-shadow: 5px 5px 5px 2px var(--search-bar-focus-border-color);
+}
+
+.main-search button {
+  margin-bottom: 1.25rem;
+  margin-right: 1rem;
+  margin-top: 1.25rem;
+
+  svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+}

--- a/assets/css/2-components/6-secondary-search.css
+++ b/assets/css/2-components/6-secondary-search.css
@@ -1,0 +1,60 @@
+/* stylelint-disable selector-class-pattern */
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
+
+.secondary-search {
+  background-color: var(--search-bar-background-color);
+  border-radius: 0.75rem;
+  border-width: 2px;
+  display: flex;
+  font-size: 1rem;
+  justify-content: center;
+  line-height: 2rem;
+  max-width: 20rem;
+  outline-offset: -2px;
+  overflow: hidden;
+  padding: 0.3rem;
+
+  .search-bar {
+    background-color: var(--search-bar-background-color);
+    color: var(--search-bar-color);
+    display: block;
+    font-size: 1.5rem;
+    line-height: 2rem;
+    padding: 0.5rem;
+    flex-grow: 1;
+    min-width: 0;
+  }
+
+  .search-bar:hover {
+    background-color: var(--search-bar-background-hover-color);
+  }
+
+  .search-bar:focus {
+    background-color: var(--search-bar-background-focus-color);
+    outline: transparent solid 2px;
+    outline-offset: 2px;
+  }
+}
+
+.secondary-search:focus-within {
+  border-color: var(--search-bar-focus-border-color);
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+
+  /* offset-x | offset-y | blur-radius | spread-radius | color */
+  box-shadow: 4px 4px 4px 1px var(--search-bar-focus-border-color);
+}
+
+.secondary-search button {
+  margin-bottom: 1.25rem;
+  margin-right: 1rem;
+  margin-top: 1.25rem;
+
+  svg {
+    width: 1em;
+    height: 1em;
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+}

--- a/assets/css/3-screens/4-front-page.css
+++ b/assets/css/3-screens/4-front-page.css
@@ -13,65 +13,6 @@
   text-align: center;
 }
 
-.main-search {
-  background-color: var(--search-bar-background-color);
-  border-radius: 0.75rem;
-  border-width: 2px;
-  display: flex;
-  font-size: 1.5rem;
-  justify-content: center;
-  line-height: 2rem;
-  max-width: 28rem;
-  outline-offset: -2px;
-  overflow: hidden;
-  padding: 0.5rem;
-
-  .search-bar {
-    background-color: var(--search-bar-background-color);
-    color: var(--search-bar-color);
-    display: block;
-    margin-left: 0.5rem;
-    font-size: 1.5rem;
-    line-height: 2rem;
-    padding: 0.5rem;
-    flex-grow: 1;
-    min-width: 0;
-  }
-
-  .search-bar:hover {
-    background-color: var(--search-bar-background-hover-color);
-  }
-
-  .search-bar:focus {
-    background-color: var(--search-bar-background-focus-color);
-    outline: 2px solid transparent;
-    outline-offset: 2px;
-  }
-}
-
-.main-search:focus-within {
-  border-color: var(--search-bar-focus-border-color);
-  transition-property: box-shadow;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 400ms;
-
-  /* offset-x | offset-y | blur-radius | spread-radius | color */
-  box-shadow: 5px 5px 5px 2px var(--search-bar-focus-border-color);
-}
-
-.main-search button {
-  margin-bottom: 1.25rem;
-  margin-right: 1rem;
-  margin-top: 1.25rem;
-
-  svg {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-top: auto;
-    margin-bottom: auto;
-  }
-}
-
 section#main-page-buttons {
   border-top: 1px solid var(--text-color);
   border-color: var(--navbar-background-color);

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -8,6 +8,8 @@
 @import "2-components/2-package-component.css";
 @import "2-components/3-breadcrumb.css";
 @import "2-components/4-license.css";
+@import "2-components/5-primary-search.css";
+@import "2-components/6-secondary-search.css";
 
 @import "3-screens/1-package/1-package.css";
 @import "3-screens/1-package/2-release-changelog.css";
@@ -75,16 +77,19 @@
   }
 }
 
+ul.package-list > * {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-left: 1rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
 .package-list-item {
   list-style: none;
 
   a {
     display: block;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-    padding-left: 1rem;
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
     font-size: 1.25rem;
     line-height: 1.75rem;
   }

--- a/flora.cabal
+++ b/flora.cabal
@@ -39,7 +39,6 @@ common common-extensions
     OverloadedStrings
     PackageImports
     PolyKinds
-    QuasiQuotes
     RecordWildCards
     StrictData
     TypeFamilies
@@ -223,10 +222,13 @@ library flora-web
     FloraWeb.Components.CategoryCard
     FloraWeb.Components.Footer
     FloraWeb.Components.Header
+    FloraWeb.Components.Icons
+    FloraWeb.Components.MainSearchBar
     FloraWeb.Components.Navbar
     FloraWeb.Components.PackageListHeader
     FloraWeb.Components.PackageListItem
     FloraWeb.Components.PaginationNav
+    FloraWeb.Components.SlimSearchBar
     FloraWeb.Components.Utils
     FloraWeb.Components.VersionListHeader
     FloraWeb.Embedded

--- a/src/core/Flora/Search.hs
+++ b/src/core/Flora/Search.hs
@@ -21,14 +21,19 @@ data SearchAction
   = ListAllPackages
   | ListAllPackagesInNamespace Namespace
   | SearchPackages Text
-  | DependentsOf Namespace PackageName
+  | DependentsOf Namespace PackageName (Maybe Text)
   deriving (Eq, Ord, Show)
 
 instance Display SearchAction where
   displayBuilder ListAllPackages = "Packages"
   displayBuilder (ListAllPackagesInNamespace namespace) = "Packages in " <> displayBuilder namespace
   displayBuilder (SearchPackages title) = "\"" <> Builder.fromText title <> "\""
-  displayBuilder (DependentsOf namespace packageName) = "Dependents of " <> displayBuilder namespace <> "/" <> displayBuilder packageName
+  displayBuilder (DependentsOf namespace packageName mbSearchString) =
+    "Dependents of "
+      <> displayBuilder namespace
+      <> "/"
+      <> displayBuilder packageName
+      <> foldMap (\searchString -> " \"" <> Builder.fromText searchString <> "\"") mbSearchString
 
 searchPackageByName
   :: (DB :> es, Log :> es, Time :> es)

--- a/src/web/FloraWeb/Components/Icons.hs
+++ b/src/web/FloraWeb/Components/Icons.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module FloraWeb.Components.Icons
+  ( usageInstructionTooltip
+  , chevronRightOutline
+  , pen
+  , lookingGlass
+  ) where
+
+import Data.Text (Text)
+import Lucid
+import Lucid.Svg
+  ( d_
+  , fill_
+  , path_
+  , stroke_
+  , stroke_linecap_
+  , stroke_linejoin_
+  , stroke_width_
+  , viewBox_
+  )
+import PyF
+
+import FloraWeb.Pages.Templates.Types (FloraHTML)
+
+usageInstructionTooltip :: FloraHTML
+usageInstructionTooltip =
+  toHtmlRaw @Text
+    [str|
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="tooltip"> 
+  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM8.94 6.94a.75.75 0 11-1.061-1.061 3 3 0 112.871 5.026v.345a.75.75 0 01-1.5 0v-.5c0-.72.57-1.172 1.081-1.287A1.5 1.5 0 108.94 6.94zM10 15a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" /> 
+</svg> 
+|]
+
+chevronRightOutline :: FloraHTML
+chevronRightOutline =
+  toHtmlRaw @Text
+    [str|
+<svg xmlns="http://www.w3.org/2000/svg" class="breadcrumb" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" stroke="currentColor" /> 
+</svg>
+|]
+
+pen :: FloraHTML
+pen =
+  toHtmlRaw @Text
+    [str|
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="pen">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
+</svg>
+|]
+
+lookingGlass :: FloraHTML
+lookingGlass =
+  button_ [type_ "submit"] $
+    svg_ [xmlns_ "http://www.w3.org/2000/svg", style_ "color: gray", fill_ "none", viewBox_ "0 0 24 24", stroke_ "currentColor"] $
+      path_ [stroke_linecap_ "round", stroke_linejoin_ "round", stroke_width_ "2", d_ "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"]

--- a/src/web/FloraWeb/Components/MainSearchBar.hs
+++ b/src/web/FloraWeb/Components/MainSearchBar.hs
@@ -1,0 +1,23 @@
+module FloraWeb.Components.MainSearchBar where
+
+import FloraWeb.Components.Icons
+import FloraWeb.Pages.Templates.Types (FloraHTML)
+import Lucid
+
+mainSearchBar :: FloraHTML
+mainSearchBar =
+  form_ [action_ "/search", method_ "GET"] $ do
+    div_ [class_ "main-search"] $ do
+      label_ [for_ "search"] ""
+      input_
+        [ class_
+            "search-bar"
+        , type_ "search"
+        , id_ "search"
+        , name_ "q"
+        , placeholder_ "Find a package"
+        , value_ ""
+        , tabindex_ "1"
+        , autofocus_
+        ]
+      lookingGlass

--- a/src/web/FloraWeb/Components/PaginationNav.hs
+++ b/src/web/FloraWeb/Components/PaginationNav.hs
@@ -49,8 +49,8 @@ mkURL (ListAllPackagesInNamespace namespace) pageNumber =
   "/" <> toUrlPiece (Links.namespaceLink namespace pageNumber)
 mkURL (SearchPackages searchTerm) pageNumber =
   "/" <> toUrlPiece (Links.packageSearchLink searchTerm pageNumber)
-mkURL (DependentsOf namespace packageName) pageNumber =
-  "/" <> toUrlPiece (Links.packageDependents namespace packageName pageNumber)
+mkURL (DependentsOf namespace packageName mbSearchString) pageNumber =
+  "/" <> toUrlPiece (Links.packageDependents namespace packageName pageNumber mbSearchString)
 
 paginate
   :: Word

--- a/src/web/FloraWeb/Components/SlimSearchBar.hs
+++ b/src/web/FloraWeb/Components/SlimSearchBar.hs
@@ -1,0 +1,30 @@
+module FloraWeb.Components.SlimSearchBar (slimSearchBar, SearchBarOptions (..)) where
+
+import Data.Text (Text)
+import FloraWeb.Components.Icons
+import FloraWeb.Pages.Templates.Types (FloraHTML)
+import Lucid
+
+data SearchBarOptions = SearchBarOptions
+  { actionUrl :: Text
+  , placeholder :: Text
+  , value :: Text
+  }
+
+slimSearchBar :: SearchBarOptions -> FloraHTML
+slimSearchBar SearchBarOptions{actionUrl, placeholder, value} =
+  form_ [action_ actionUrl, method_ "GET"] $! do
+    div_ [class_ "secondary-search"] $ do
+      label_ [for_ "search"] ""
+      input_
+        [ class_
+            "search-bar"
+        , type_ "search"
+        , id_ "search"
+        , name_ "q"
+        , placeholder_ placeholder
+        , value_ value
+        , tabindex_ "1"
+        , autofocus_
+        ]
+      lookingGlass

--- a/src/web/FloraWeb/Components/Utils.hs
+++ b/src/web/FloraWeb/Components/Utils.hs
@@ -2,7 +2,7 @@ module FloraWeb.Components.Utils where
 
 import Data.Text (Text)
 import FloraWeb.Pages.Templates.Types (FloraHTML)
-import Lucid (Attribute, a_, class_, href_, role_, toHtml)
+import Lucid
 import Lucid.Base (makeAttribute)
 
 text :: Text -> FloraHTML

--- a/src/web/FloraWeb/Links.hs
+++ b/src/web/FloraWeb/Links.hs
@@ -82,14 +82,20 @@ packageDependencies namespace packageName version =
     /: packageName
     /: version
 
-packageDependents :: Namespace -> PackageName -> Positive Word -> Link
-packageDependents namespace packageName pageNumber =
+packageDependents
+  :: Namespace
+  -> PackageName
+  -> Positive Word
+  -> Maybe Text
+  -> Link
+packageDependents namespace packageName pageNumber search =
   links
     // Web.packages
     // Web.showDependents
     /: namespace
     /: packageName
     /: Just pageNumber
+    /: search
 
 packageVersions :: Namespace -> PackageName -> Link
 packageVersions namespace packageName =

--- a/src/web/FloraWeb/Pages/Routes/Packages.hs
+++ b/src/web/FloraWeb/Pages/Routes/Packages.hs
@@ -38,6 +38,7 @@ data Routes' mode = Routes'
           :> Capture "package" PackageName
           :> "dependents"
           :> QueryParam "page" (Positive Word)
+          :> QueryParam "q" Text
           :> Get '[HTML] (Html ())
   , showVersionDependents
       :: mode
@@ -46,6 +47,7 @@ data Routes' mode = Routes'
           :> Capture "version" Version
           :> "dependents"
           :> QueryParam "page" (Positive Word)
+          :> QueryParam "q" Text
           :> Get '[HTML] (Html ())
   , showDependencies
       :: mode

--- a/src/web/FloraWeb/Pages/Templates/Pages/Home.hs
+++ b/src/web/FloraWeb/Pages/Templates/Pages/Home.hs
@@ -6,26 +6,17 @@ import CMarkGFM
 import Control.Monad.Reader
 import Data.Text (Text)
 import Lucid
-import Lucid.Svg
-  ( d_
-  , fill_
-  , path_
-  , stroke_
-  , stroke_linecap_
-  , stroke_linejoin_
-  , stroke_width_
-  , viewBox_
-  )
 import PyF
 
 import Flora.Environment
+import FloraWeb.Components.MainSearchBar (mainSearchBar)
 import FloraWeb.Pages.Templates.Types
 
 show :: FloraHTML
 show = do
   banner
   div_ [class_ "container-small"] $ do
-    searchBar
+    mainSearchBar
     buttons
 
 banner :: FloraHTML
@@ -33,26 +24,6 @@ banner = do
   div_ [class_ "relative"] $
     h1_ [class_ "main-title"] $
       span_ [class_ "main-title"] "Search Haskell packages on Flora"
-
-searchBar :: FloraHTML
-searchBar =
-  form_ [action_ "/search", method_ "GET"] $ do
-    div_ [class_ "main-search"] $ do
-      label_ [for_ "search"] ""
-      input_
-        [ class_
-            "search-bar"
-        , type_ "search"
-        , id_ "search"
-        , name_ "q"
-        , placeholder_ "Find a package"
-        , value_ ""
-        , tabindex_ "1"
-        , autofocus_
-        ]
-      button_ [type_ "submit"] $
-        svg_ [xmlns_ "http://www.w3.org/2000/svg", style_ "color: gray", fill_ "none", viewBox_ "0 0 24 24", stroke_ "currentColor"] $
-          path_ [stroke_linecap_ "round", stroke_linejoin_ "round", stroke_width_ "2", d_ "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"]
 
 buttons :: FloraHTML
 buttons =

--- a/src/web/FloraWeb/Pages/Templates/Pages/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Pages/Packages.hs
@@ -13,9 +13,9 @@ import Lucid.Orphans ()
 import Flora.Model.Category.Types (Category (..))
 import Flora.Model.Package.Types
 import Flora.Model.Release.Types (Release (..))
+import FloraWeb.Components.Icons
 import FloraWeb.Pages.Templates.Packages
-  ( chevronRightOutline
-  , displayCategories
+  ( displayCategories
   , displayDependencies
   , displayDependents
   , displayInstructions

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -135,7 +135,7 @@ testCorrectNumberInHaskellNamespace = do
 
 testBytestringDependents :: TestEff ()
 testBytestringDependents = do
-  results <- Query.getAllPackageDependentsWithLatestVersion (Namespace "haskell") (PackageName "bytestring") (0, 30)
+  results <- Query.getAllPackageDependentsWithLatestVersion (Namespace "haskell") (PackageName "bytestring") (0, 30) Nothing
   assertEqual
     24
     (Vector.length results)


### PR DESCRIPTION
closes #388
supercedes #389

## Proposed changes

Original changes by @dylan-thinnes: 

> Reverse dependency lists (a.k.a dependents) can get huge, e.g. for the lens library, which makes pagination impractical. This implements a search bar in the reverse dependencies page.

## Contributor checklist

- [x] My PR is related to #388
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
