### PR TITLE
[FLORA-35] Search bar modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add search bar for reverse dependencies ([#476](https://github.com/flora-pm/flora-server/pull/476))
 * Support non Hackage repo URLs ([#479](https://github.com/flora-pm/flora-server/pull/479))
 * Add description field in package index ([#486](https://github.com/flora-pm/flora-server/pull/486))
+* Introduce search bar modifiers ([#487](https://github.com/flora-pm/flora-server/pull/487))
 
 ## 1.0.13 -- 2023-09-17
 * Exclude deprecated releases from latest versions and search ([#373](https://github.com/flora-pm/flora-server/pull/373))

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -6,3 +6,4 @@ slug: /
 Read more about:
 
 * [Namespaces](/namespaces)
+* [Search features](/search-features)

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -1,0 +1,14 @@
+---
+title: Search features
+slug: search-features
+---
+
+While searching for packages you may want to refine the search terms with modifiers. 
+Currently, the following modifiers are available:
+
+* `depends:<@namespace>/<packagename>`: Shows the dependents page for a package
+* `in:<@namespace> <packagename>`: Searches for a package name in the specified namespace
+* `in:<@namespace>`: Lists packages in a namespace
+
+These modifiers must be placed at the very beginning of the search query, otherwise they will
+be interpreted as a search term.

--- a/flora.cabal
+++ b/flora.cabal
@@ -170,7 +170,6 @@ library
     , monad-time-effectful
     , mtl
     , odd-jobs
-    , one-time-password
     , openapi3
     , optics-core
     , password
@@ -465,6 +464,7 @@ test-suite flora-test
     , monad-time-effectful
     , optics-core
     , password
+    , password-types
     , pg-entity
     , pg-transact
     , pg-transact-effectful
@@ -480,6 +480,7 @@ test-suite flora-test
     , text
     , time
     , transformers
+    , typed-process
     , uuid
     , vector
     , zlib
@@ -491,6 +492,7 @@ test-suite flora-test
     Flora.ImportSpec
     Flora.OddJobSpec
     Flora.PackageSpec
+    Flora.SearchSpec
     Flora.TemplateSpec
     Flora.TestUtils
     Flora.UserSpec

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,11 +7,6 @@ source ./environment.test.sh
 
 export DATALOG_DIR="cbits/"
 
-make db-drop
-make db-setup
-
-cabal run -- flora-cli create-user --username "hackage-user" --email "tech@flora.pm" --password "foobar2000"
-
 if [ -z "$1" ] ;
 then
   cabal test

--- a/src/core/Flora/Model/Package/Types.hs
+++ b/src/core/Flora/Model/Package/Types.hs
@@ -85,7 +85,7 @@ extractPackageNameText (PackageName text) = text
 
 parsePackageName :: Text -> Maybe PackageName
 parsePackageName txt =
-  if matches "[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*" txt
+  if matches "^[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*$" txt
     then Just $ PackageName txt
     else Nothing
 
@@ -109,7 +109,7 @@ packageNameSchema :: Schema
 packageNameSchema =
   mempty
     & #description
-      ?~ "Name of a package\n It corresponds to the regular expression: `[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*`"
+      ?~ "Name of a package\n It corresponds to the regular expression: `^[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*$`"
 
 newtype Namespace = Namespace Text
   deriving stock (Show, Generic)
@@ -148,7 +148,7 @@ instance FromHttpApiData Namespace where
 
 parseNamespace :: Text -> Maybe Namespace
 parseNamespace txt =
-  if matches "@[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*" txt
+  if matches "^@[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*$" txt
     then Just $ Namespace txt
     else Nothing
 

--- a/src/web/FloraWeb/Components/Navbar.hs
+++ b/src/web/FloraWeb/Components/Navbar.hs
@@ -110,18 +110,24 @@ userMenu = do
 navbarSearch :: FloraHTML
 navbarSearch = do
   flag <- asks displayNavbarSearch
+  mContent <- asks navbarSearchContent
   if flag
     then do
+      let contentValue =
+            case mContent of
+              Nothing -> []
+              Just content -> [value_ content]
       form_ [action_ "/search", method_ "GET"] $ do
         div_ [class_ "flex items-center py-2"] $ do
           label_ [for_ "search"] ""
-          input_
+          input_ $
             [ class_ "navbar-search"
             , id_ "search"
             , type_ "search"
             , name_ "q"
             , placeholder_ "Search a package"
             ]
+              ++ contentValue
     else pure mempty
 
 logOff :: Maybe User -> PersistentSessionId -> FloraHTML

--- a/src/web/FloraWeb/Pages/Server/Packages.hs
+++ b/src/web/FloraWeb/Pages/Server/Packages.hs
@@ -77,7 +77,7 @@ showNamespaceHandler namespace pageParam = do
   let pageNumber = pageParam ?: PositiveUnsafe 1
   session <- getSession
   templateDefaults <- fromSession session defaultTemplateEnv
-  (count', results) <- Search.listAllPackagesInNamespace namespace (fromPage pageNumber)
+  (count', results) <- Search.listAllPackagesInNamespace (fromPage pageNumber) namespace
   if extractNamespaceText namespace == "haskell"
     then
       render templateDefaults $

--- a/src/web/FloraWeb/Pages/Server/Search.hs
+++ b/src/web/FloraWeb/Pages/Server/Search.hs
@@ -4,14 +4,13 @@ import Data.Positive
 import Data.Text (Text)
 import Data.Vector qualified as Vector
 import Lucid (Html)
-import Optics.Core
 import Servant (ServerT)
 
 import Flora.Model.Package.Types
 import Flora.Search qualified as Search
 import FloraWeb.Common.Pagination
 import FloraWeb.Pages.Routes.Search (Routes, Routes' (..))
-import FloraWeb.Pages.Templates (TemplateEnv (..), defaultTemplateEnv, fromSession, render)
+import FloraWeb.Pages.Templates (defaultTemplateEnv, fromSession, render)
 import FloraWeb.Pages.Templates.Screens.Search qualified as Search
 import FloraWeb.Session
 
@@ -23,18 +22,10 @@ server =
 
 searchHandler :: Maybe Text -> Maybe (Positive Word) -> FloraPage (Html ())
 searchHandler Nothing pageParam = searchHandler (Just "") pageParam
-searchHandler (Just "") pageParam = do
-  let pageNumber = pageParam ?: PositiveUnsafe 1
-  session <- getSession
-  templateDefaults <- fromSession session defaultTemplateEnv
-  (count, results) <- Search.listAllPackages (fromPage pageNumber)
-  let (templateEnv :: TemplateEnv) =
-        templateDefaults & #displayNavbarSearch .~ False
-  render templateEnv $ Search.showAllPackages count pageNumber results
 searchHandler (Just searchString) pageParam = do
   let pageNumber = pageParam ?: PositiveUnsafe 1
   session <- getSession
   templateEnv <- fromSession session defaultTemplateEnv
-  (count, results) <- Search.searchPackageByName (fromPage pageNumber) searchString
+  (count, results) <- Search.search (fromPage pageNumber) searchString
   let (matchVector, packagesInfo) = Vector.partition (\p -> p.name == PackageName searchString) results
   render templateEnv $ Search.showResults searchString count pageNumber matchVector packagesInfo

--- a/src/web/FloraWeb/Pages/Server/Search.hs
+++ b/src/web/FloraWeb/Pages/Server/Search.hs
@@ -10,7 +10,7 @@ import Flora.Model.Package.Types
 import Flora.Search qualified as Search
 import FloraWeb.Common.Pagination
 import FloraWeb.Pages.Routes.Search (Routes, Routes' (..))
-import FloraWeb.Pages.Templates (defaultTemplateEnv, fromSession, render)
+import FloraWeb.Pages.Templates
 import FloraWeb.Pages.Templates.Screens.Search qualified as Search
 import FloraWeb.Session
 
@@ -25,7 +25,11 @@ searchHandler Nothing pageParam = searchHandler (Just "") pageParam
 searchHandler (Just searchString) pageParam = do
   let pageNumber = pageParam ?: PositiveUnsafe 1
   session <- getSession
-  templateEnv <- fromSession session defaultTemplateEnv
+  templateDefaults <- fromSession session defaultTemplateEnv
+  let templateEnv =
+        templateDefaults
+          { navbarSearchContent = Just searchString
+          }
   (count, results) <- Search.search (fromPage pageNumber) searchString
   let (matchVector, packagesInfo) = Vector.partition (\p -> p.name == PackageName searchString) results
   render templateEnv $ Search.showResults searchString count pageNumber matchVector packagesInfo

--- a/src/web/FloraWeb/Pages/Templates/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Packages.hs
@@ -6,7 +6,7 @@ import Control.Monad.Reader (ask)
 import Data.Foldable (fold, forM_)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromJust, fromMaybe, isJust)
+import Data.Maybe (fromJust, isJust)
 import Data.Positive
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -37,7 +37,6 @@ import Flora.Search (SearchAction (..))
 import FloraWeb.Components.Icons
 import FloraWeb.Components.PackageListItem (licenseIcon, packageListItem, requirementListItem)
 import FloraWeb.Components.PaginationNav (paginationNav)
-import FloraWeb.Components.SlimSearchBar
 import FloraWeb.Components.Utils
 import FloraWeb.Links qualified as Links
 import FloraWeb.Pages.Templates (FloraHTML, TemplateEnv (..))
@@ -101,15 +100,11 @@ showDependents
   -> Word
   -> Vector DependencyInfo
   -> Positive Word
-  -> Maybe Text
   -> FloraHTML
-showDependents namespace packageName release count packagesInfo currentPage mSearch =
+showDependents namespace packageName release count packagesInfo currentPage =
   div_ [class_ "container"] $ do
     presentationHeaderForSubpage namespace packageName release Dependents count
-    let placeholder = fromMaybe "Search dependents" mSearch
-    let value = fromMaybe "" mSearch
     ul_ [class_ "package-list"] $ do
-      slimSearchBar (SearchBarOptions{actionUrl = "", placeholder, value})
       Vector.forM_
         packagesInfo
         ( \dep ->

--- a/src/web/FloraWeb/Pages/Templates/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Packages.hs
@@ -66,7 +66,7 @@ presentationHeaderForSubpage namespace packageName release target numberOfPackag
     span_ [class_ "headline"] $ do
       displayNamespace namespace
       chevronRightOutline
-      linkToPackageWithVersion namespace packageName (release.version)
+      linkToPackageWithVersion namespace packageName release.version
       chevronRightOutline
       toHtml (display target)
   p_ [class_ "synopsis"] $

--- a/src/web/FloraWeb/Pages/Templates/Types.hs
+++ b/src/web/FloraWeb/Pages/Templates/Types.hs
@@ -58,6 +58,7 @@ data TemplateEnv = TemplateEnv
   , activeElements :: ActiveElements
   , assets :: Assets
   , indexPage :: Bool
+  , navbarSearchContent :: Maybe Text
   }
   deriving stock (Show, Generic)
 
@@ -82,6 +83,7 @@ data TemplateDefaults = TemplateDefaults
   , features :: FeatureEnv
   , activeElements :: ActiveElements
   , indexPage :: Bool
+  , navbarSearchContent :: Maybe Text
   }
   deriving stock (Show, Generic)
 
@@ -108,6 +110,7 @@ defaultTemplateEnv =
     , features = FeatureEnv Nothing
     , activeElements = defaultActiveElements
     , indexPage = True
+    , navbarSearchContent = Nothing
     }
 
 -- | ⚠  DO NOT USE THIS FUNCTION IF YOU DON'T KNOW WHAT YOU'RE DOING

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -228,9 +228,9 @@ testReleaseDeprecation = do
   assertEqual 68 (length result)
 
   binary <- fromJust <$> Query.getPackageByNamespaceAndName (Namespace "haskell") (PackageName "binary")
-  deprecatedBinaryVersion' <- assertJust =<< Query.getReleaseByVersion (binary.packageId) (mkVersion [0, 10, 0, 0])
+  deprecatedBinaryVersion' <- assertJust =<< Query.getReleaseByVersion binary.packageId (mkVersion [0, 10, 0, 0])
   Update.setReleasesDeprecationMarker (Vector.singleton (True, deprecatedBinaryVersion'.releaseId))
-  deprecatedBinaryVersion <- assertJust =<< Query.getReleaseByVersion (binary.packageId) (mkVersion [0, 10, 0, 0])
+  deprecatedBinaryVersion <- assertJust =<< Query.getReleaseByVersion binary.packageId (mkVersion [0, 10, 0, 0])
   assertEqual deprecatedBinaryVersion.deprecated (Just True)
 
 ---

--- a/test/Flora/SearchSpec.hs
+++ b/test/Flora/SearchSpec.hs
@@ -1,0 +1,45 @@
+module Flora.SearchSpec where
+
+import Test.Tasty
+
+import Flora.Model.Package.Types
+import Flora.Search
+import Flora.TestUtils
+
+spec :: TestEff TestTree
+spec =
+  testThese
+    "Search bar mdifiers"
+    [ testThis "Parsing of \"depends:<@namespace>/<packagename>\" search modifier" testParsingDependsSearchModifier
+    , testThis "Parsing of \"in:<@namespace> <packagename>\" modifier" testParsingNamespacePackageModifier
+    , testThis "Parsing of \"in:<@namespace>\" modifier" testParsingNamespaceModifier
+    , testThis "Parsing of a query containing a modifier" testParsingQueryContainingModifier
+    ]
+
+testParsingDependsSearchModifier :: TestEff ()
+testParsingDependsSearchModifier = do
+  let result = parseSearchQuery "depends:@haskell/base"
+  assertEqual
+    (Just $ DependentsOf (Namespace "@haskell") (PackageName "base") Nothing)
+    result
+
+testParsingNamespacePackageModifier :: TestEff ()
+testParsingNamespacePackageModifier = do
+  let result = parseSearchQuery "in:@haskell base"
+  assertEqual
+    (Just $ SearchPackage (Namespace "@haskell") (PackageName "base"))
+    result
+
+testParsingNamespaceModifier :: TestEff ()
+testParsingNamespaceModifier = do
+  let result = parseSearchQuery "in:@haskell"
+  assertEqual
+    (Just $ ListAllPackagesInNamespace (Namespace "@haskell"))
+    result
+
+testParsingQueryContainingModifier :: TestEff ()
+testParsingQueryContainingModifier = do
+  let result = parseSearchQuery "bah blah blah depends:@haskell/base"
+  assertEqual
+    (Just (SearchPackages "bah blah blah depends:@haskell/base"))
+    result

--- a/test/Flora/SearchSpec.hs
+++ b/test/Flora/SearchSpec.hs
@@ -27,7 +27,7 @@ testParsingNamespacePackageModifier :: TestEff ()
 testParsingNamespacePackageModifier = do
   let result = parseSearchQuery "in:@haskell base"
   assertEqual
-    (Just $ SearchPackage (Namespace "@haskell") (PackageName "base"))
+    (Just $ SearchInNamespace (Namespace "@haskell") (PackageName "base"))
     result
 
 testParsingNamespaceModifier :: TestEff ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Data.Password.Types
 import Effectful
 import Effectful.Fail (runFailIO)
 import Effectful.Log qualified as Log
@@ -9,18 +10,21 @@ import Effectful.Time
 import Log.Backend.StandardOutput qualified as Log
 import Log.Data
 import System.IO
+import System.Process.Typed qualified as Process
 import Test.Tasty (defaultMain, testGroup)
-
-import Flora.Model.BlobStore.API
 
 import Flora.BlobSpec qualified as BlobSpec
 import Flora.CabalSpec qualified as CabalSpec
 import Flora.CategorySpec qualified as CategorySpec
 import Flora.Environment
 import Flora.ImportSpec qualified as ImportSpec
+import Flora.Model.BlobStore.API
 import Flora.Model.PackageIndex.Update qualified as Update
+import Flora.Model.User (UserCreationForm (..), hashPassword, mkUser)
+import Flora.Model.User.Update qualified as Update
 import Flora.OddJobSpec qualified as OddJobSpec
 import Flora.PackageSpec qualified as PackageSpec
+import Flora.SearchSpec qualified as SearchSpec
 import Flora.TemplateSpec qualified as TemplateSpec
 import Flora.TestUtils
 import Flora.UserSpec qualified as UserSpec
@@ -28,6 +32,8 @@ import Flora.UserSpec qualified as UserSpec
 main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
+  Process.runProcess "make db-drop"
+  Process.runProcess "make db-setup"
   env <- runEff getFloraTestEnv
   fixtures <- runEff $ Log.withStdOutLogger $ \stdOutLogger -> do
     runTime
@@ -38,6 +44,9 @@ main = do
     . runFailIO
     $ do
       Update.createPackageIndex "hackage" "" "" Nothing
+      password <- hashPassword $ mkPassword "foobar2000"
+      templateUser <- mkUser $ UserCreationForm "hackage-user" "tech@flora.pm" password
+      Update.insertUser templateUser
       testMigrations
       f' <- getFixtures
       importAllPackages f'
@@ -54,4 +63,5 @@ specs fixtures =
   , CabalSpec.spec
   , ImportSpec.spec fixtures
   , BlobSpec.spec
+  , SearchSpec.spec
   ]


### PR DESCRIPTION
## Proposed changes

This PR introduces modifiers for the search bar:

* `depends:<@namespace>/<packagename>` 
   Shows the dependents page for a package
* `in:<@namespace> <packagename>`
   Search for a package name in the specified namespace
* `in:<@namespace>`
   List packages in a namespace

Also the "Show dependents" page will be implemented in these terms, and we'll get rid of the extraneous search bar.

![image](https://github.com/flora-pm/flora-server/assets/15848443/8f39b8e6-4100-41f8-bdd7-c1dd0b710740)

![Screenshot 2023-12-13 at 14-50-39 Flora Package](https://github.com/flora-pm/flora-server/assets/15848443/27af96fa-9336-4e35-a19e-c7fa8f38fcc6)
![Screenshot 2023-12-13 at 14-50-29 Flora Package](https://github.com/flora-pm/flora-server/assets/15848443/2def1453-1df6-4178-b7d0-a4374660db6b)
![Screenshot 2023-12-13 at 14-49-49 @haskell_base](https://github.com/flora-pm/flora-server/assets/15848443/2ba7822d-81b9-4e74-9d79-eba32642bfdd)


## Contributor checklist

- [x] My PR is related to #35
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] I have created or updated existing documentation
