### PR TITLE
[FLORA-62] Search executable by name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,4 @@
 - [ ] My PR is related to \<insert ticket number> 
 - [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
 - [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
+- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.17 -- XXXX-XX-XX
+
+* Add `exe:` search modifier to look up packages by executable name ([#529](https://github.com/flora-pm/flora-server/pull/529))
+
 ## 1.0.16 -- 2024-02-26
 
 * Add badge component for custom build type ([#517](https://github.com/flora-pm/flora-server/pull/517))

--- a/app/cli/DesignSystem.hs
+++ b/app/cli/DesignSystem.hs
@@ -100,6 +100,7 @@ packageListItemExample =
     , "Basic libraries"
     , mkVersion [4, 16, 0, 0]
     , License (simpleLicenseExpression BSD_3_Clause)
+    , Vector.empty
     )
 
 categoryCardExample :: FloraHTML

--- a/assets/css/2-components/9-terminal-icon.css
+++ b/assets/css/2-components/9-terminal-icon.css
@@ -1,0 +1,10 @@
+/* stylelint-disable selector-class-pattern */
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
+
+.terminal-icon {
+  height: 1.25rem;
+  width: 1.25rem;
+  display: inline;
+  margin-top: -0.25rem;
+}
+

--- a/assets/css/2-components/9-terminal-icon.css
+++ b/assets/css/2-components/9-terminal-icon.css
@@ -7,4 +7,3 @@
   display: inline;
   margin-top: -0.25rem;
 }
-

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -12,6 +12,7 @@
 @import "2-components/6-secondary-search.css";
 @import "2-components/7-button.css";
 @import "2-components/8-alert.css";
+@import "2-components/9-terminal-icon.css";
 
 @import "3-screens/1-package/1-package.css";
 @import "3-screens/1-package/2-release-changelog.css";

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -9,7 +9,7 @@ Currently, the following modifiers are available:
 * `depends:<@namespace>/<packagename>`: Shows the dependents page for a package
 * `in:<@namespace> <packagename>`: Searches for a package name in the specified namespace
 * `in:<@namespace>`: Lists packages in a namespace
-* `exe:<executable namme>`: Search for packages that have an executable component with <executable name> as the search string
+* `exe:<executable name>`: Search for packages that have an executable component with `<executable name>` as the search string
 
 These modifiers must be placed at the very beginning of the search query, otherwise they will be interpreted as a search term.
 

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -9,6 +9,8 @@ Currently, the following modifiers are available:
 * `depends:<@namespace>/<packagename>`: Shows the dependents page for a package
 * `in:<@namespace> <packagename>`: Searches for a package name in the specified namespace
 * `in:<@namespace>`: Lists packages in a namespace
+* `exe:<executable namme>`: Search for packages that have an executable component with <executable name> as the search string
 
-These modifiers must be placed at the very beginning of the search query, otherwise they will
-be interpreted as a search term.
+These modifiers must be placed at the very beginning of the search query, otherwise they will be interpreted as a search term.
+
+They are not yet composable.

--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -477,6 +477,7 @@ getPackagesFromCategoryWithLatestVersion categoryId = dbtToEff $ query Select q 
                     , lv.version
                     , lv.license
                     , 1
+                    , array[]
       from latest_versions as lv
         inner join package_categories as p1 on p1.package_id = lv.package_id
         inner join categories as c2 on c2.category_id = p1.category_id
@@ -499,6 +500,7 @@ searchPackage (offset, limit) searchString =
               , lv."version"
               , lv."license"
               , word_similarity(lv.name, ?) as rating
+              , array[]
         FROM latest_versions as lv
         WHERE ? <% lv.name
         GROUP BY
@@ -531,6 +533,7 @@ searchPackageByNamespace (offset, limit) namespace searchString =
               , lv."version"
               , lv."license"
               , word_similarity(lv.name, ?) as rating
+              , array[]
         FROM latest_versions as lv
         WHERE 
         ? <% lv."name"
@@ -563,12 +566,13 @@ searchExecutable (offset, limit) searchString =
                     , l2.synopsis
                     , l2.version
                     , l2.license
-                    , word_similarity(l2.name, ?) AS rating
+                    , word_similarity(p0.component_name, ?) AS rating
+                    , array(select p0.component_name)
       FROM package_components AS p0
            INNER JOIN releases AS r1 ON p0.release_id = r1.release_id
            INNER JOIN latest_versions AS l2 ON r1.package_id = l2.package_id
       WHERE p0.component_type = 'executable'
-        AND ? <% l2.name
+        AND ? <% p0.component_name
       ORDER BY rating DESC
              , l2.name ASC
       OFFSET ?
@@ -594,6 +598,7 @@ listAllPackages (offset, limit) =
           , lv."version"
           , lv."license"
           , (1.0::real) as rating
+          , array[]
     FROM latest_versions as lv
     GROUP BY
         lv."namespace"
@@ -626,6 +631,7 @@ listAllPackagesInNamespace (offset, limit) namespace =
           , lv."version"
           , lv."license"
           , (1.0::real) as rating
+          , array[]
     FROM latest_versions as lv
     WHERE lv."namespace" = ?
     GROUP BY

--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -477,7 +477,7 @@ getPackagesFromCategoryWithLatestVersion categoryId = dbtToEff $ query Select q 
                     , lv.version
                     , lv.license
                     , 1
-                    , array[]
+                    , array[]::text[]
       from latest_versions as lv
         inner join package_categories as p1 on p1.package_id = lv.package_id
         inner join categories as c2 on c2.category_id = p1.category_id
@@ -500,7 +500,7 @@ searchPackage (offset, limit) searchString =
               , lv."version"
               , lv."license"
               , word_similarity(lv.name, ?) as rating
-              , array[]
+              , array[]::text[]
         FROM latest_versions as lv
         WHERE ? <% lv.name
         GROUP BY
@@ -533,7 +533,7 @@ searchPackageByNamespace (offset, limit) namespace searchString =
               , lv."version"
               , lv."license"
               , word_similarity(lv.name, ?) as rating
-              , array[]
+              , array[]::text[]
         FROM latest_versions as lv
         WHERE 
         ? <% lv."name"
@@ -598,7 +598,7 @@ listAllPackages (offset, limit) =
           , lv."version"
           , lv."license"
           , (1.0::real) as rating
-          , array[]
+          , array[]::text[]
     FROM latest_versions as lv
     GROUP BY
         lv."namespace"
@@ -631,7 +631,7 @@ listAllPackagesInNamespace (offset, limit) namespace =
           , lv."version"
           , lv."license"
           , (1.0::real) as rating
-          , array[]
+          , array[]::text[]
     FROM latest_versions as lv
     WHERE lv."namespace" = ?
     GROUP BY

--- a/src/core/Flora/Model/Package/Types.hs
+++ b/src/core/Flora/Model/Package/Types.hs
@@ -238,6 +238,7 @@ data PackageInfo = PackageInfo
   , version :: Version
   , license :: SPDX.License
   , rating :: Maybe Double
+  , extraData :: Vector Text
   }
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (FromRow, NFData)

--- a/src/core/Flora/Search.hs
+++ b/src/core/Flora/Search.hs
@@ -37,6 +37,7 @@ data SearchAction
       (Maybe Text)
       -- ^ Search within the package
   | SearchInNamespace Namespace PackageName
+  | SearchExecutable Text
   deriving (Eq, Ord, Show)
 
 instance Display SearchAction where
@@ -51,6 +52,8 @@ instance Display SearchAction where
       <> foldMap (\searchString -> " \"" <> Builder.fromText searchString <> "\"") mbSearchString
   displayBuilder (SearchInNamespace namespace packageName) =
     "Package " <> displayBuilder namespace <> "/" <> displayBuilder packageName
+  displayBuilder (SearchExecutable executableName) =
+    "Executable " <> displayBuilder executableName
 
 search
   :: (DB :> es, Log :> es, Time :> es)
@@ -64,6 +67,7 @@ search pagination queryString =
     Just (SearchInNamespace namespace (PackageName packageName)) -> searchPackageByNamespaceAndName pagination namespace packageName
     Just (DependentsOf namespace packageName mSearchString) -> searchDependents pagination namespace packageName mSearchString
     Just (SearchPackages _) -> searchPackageByName pagination queryString
+    Just (SearchExecutable executableName) -> searchExecutable pagination executableName
     Nothing -> searchPackageByName pagination queryString
 
 searchPackageByName
@@ -73,7 +77,6 @@ searchPackageByName
   -> Eff es (Word, Vector PackageInfo)
 searchPackageByName (offset, limit) queryString = do
   (results, duration) <- timeAction $ Query.searchPackage (offset, limit) queryString
-
   Log.logInfo "search-results" $
     object
       [ "search_string" .= queryString
@@ -89,7 +92,6 @@ searchPackageByName (offset, limit) queryString = do
             )
             (Vector.toList results)
       ]
-
   count <- Query.countPackagesByName queryString
   pure (count, results)
 
@@ -100,8 +102,9 @@ searchPackageByNamespaceAndName
   -> Text
   -> Eff es (Word, Vector PackageInfo)
 searchPackageByNamespaceAndName (offset, limit) namespace queryString = do
-  (results, duration) <- timeAction $ Query.searchPackageByNamespace (offset, limit) namespace queryString
-
+  (results, duration) <-
+    timeAction $
+      Query.searchPackageByNamespace (offset, limit) namespace queryString
   Log.logInfo "search-results" $
     object
       [ "search_string" .= queryString
@@ -117,7 +120,6 @@ searchPackageByNamespaceAndName (offset, limit) namespace queryString = do
             )
             (Vector.toList results)
       ]
-
   count <- Query.countPackagesByName queryString
   pure (count, results)
 
@@ -137,6 +139,32 @@ searchDependents pagination namespace packageName mSearchString = do
       mSearchString
   totalDependents <- Query.getNumberOfPackageDependents namespace packageName mSearchString
   pure (totalDependents, fmap dependencyInfoToPackageInfo results)
+
+searchExecutable
+  :: (DB :> es, Log :> es, Time :> es)
+  => (Word, Word)
+  -> Text
+  -> Eff es (Word, Vector PackageInfo)
+searchExecutable (offset, limit) queryString = do
+  (results, duration) <-
+    timeAction $
+      Query.searchExecutable (offset, limit) queryString
+  Log.logInfo "search-results" $
+    object
+      [ "search_string" .= queryString
+      , "duration" .= duration
+      , "results_count" .= Vector.length results
+      , "results"
+          .= List.map
+            ( \PackageInfo{namespace, name, rating} ->
+                object
+                  [ "package" .= formatPackage namespace name
+                  , "score" .= rating
+                  ]
+            )
+            (Vector.toList results)
+      ]
+  pure (fromIntegral (Vector.length results), results)
 
 dependencyInfoToPackageInfo :: DependencyInfo -> PackageInfo
 dependencyInfoToPackageInfo dep =
@@ -190,6 +218,7 @@ listAllPackages (offset, limit) = do
 -- * depends:<@namespace>/<packagename>
 -- * in:<@namespace>/<packagename>
 -- * in:<@namespace>
+-- * exe:<executable-name>
 parseSearchQuery :: Text -> Maybe SearchAction
 parseSearchQuery = \case
   (Text.stripPrefix "depends:" -> Just rest) ->
@@ -204,6 +233,7 @@ parseSearchQuery = \case
       (Just namespace, Nothing) ->
         Just $ ListAllPackagesInNamespace namespace
       _ -> Just $ SearchPackages rest
+  (Text.stripPrefix "exe:" -> Just rest) -> Just $ SearchExecutable rest
   e -> Just $ SearchPackages e
 
 -- Determine if the string is

--- a/src/web/FloraWeb/Components/Icons.hs
+++ b/src/web/FloraWeb/Components/Icons.hs
@@ -7,13 +7,17 @@ module FloraWeb.Components.Icons
   , lookingGlass
   , information
   , exception
+  , terminal
+  , license
   ) where
 
 import Data.Text (Text)
 import Lucid
 import Lucid.Svg
-  ( d_
+  ( clip_rule_
+  , d_
   , fill_
+  , fill_rule_
   , path_
   , stroke_
   , stroke_linecap_
@@ -75,3 +79,17 @@ exception =
   <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
 </svg>
   |]
+
+terminal :: FloraHTML
+terminal =
+  toHtmlRaw @Text
+    [str|
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="terminal-icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
+</svg>
+    |]
+
+license :: FloraHTML
+license =
+  svg_ [xmlns_ "http://www.w3.org/2000/svg", viewBox_ "0 0 20 20", fill_ "currentColor", class_ "license-icon"] $
+    path_ [fill_rule_ "evenodd", d_ "M10 2a.75.75 0 01.75.75v.258a33.186 33.186 0 016.668.83.75.75 0 01-.336 1.461 31.28 31.28 0 00-1.103-.232l1.702 7.545a.75.75 0 01-.387.832A4.981 4.981 0 0115 14c-.825 0-1.606-.2-2.294-.556a.75.75 0 01-.387-.832l1.77-7.849a31.743 31.743 0 00-3.339-.254v11.505a20.01 20.01 0 013.78.501.75.75 0 11-.339 1.462A18.558 18.558 0 0010 17.5c-1.442 0-2.845.165-4.191.477a.75.75 0 01-.338-1.462 20.01 20.01 0 013.779-.501V4.509c-1.129.026-2.243.112-3.34.254l1.771 7.85a.75.75 0 01-.387.83A4.98 4.98 0 015 14a4.98 4.98 0 01-2.294-.556.75.75 0 01-.387-.832L4.02 5.067c-.37.07-.738.148-1.103.232a.75.75 0 01-.336-1.462 32.845 32.845 0 016.668-.829V2.75A.75.75 0 0110 2zM5 7.543L3.92 12.33a3.499 3.499 0 002.16 0L5 7.543zm10 0l-1.08 4.787a3.498 3.498 0 002.16 0L15 7.543z", clip_rule_ "evenodd"]

--- a/src/web/FloraWeb/Components/PackageListItem.hs
+++ b/src/web/FloraWeb/Components/PackageListItem.hs
@@ -3,7 +3,6 @@
 module FloraWeb.Components.PackageListItem
   ( packageListItem
   , requirementListItem
-  , licenseIcon
   )
 where
 
@@ -12,6 +11,7 @@ import Data.List (intersperse, sortOn)
 import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Text.Display (display)
+import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import FloraWeb.Pages.Templates (FloraHTML)
 import Lucid
@@ -24,11 +24,11 @@ import Flora.Model.Requirement
   ( ComponentDependencies
   , DependencyInfo (..)
   )
+import FloraWeb.Components.Icons qualified as Icon
 import Lucid.Orphans ()
-import Lucid.Svg (clip_rule_, d_, fill_, fill_rule_, path_, viewBox_)
 
-packageListItem :: (Namespace, PackageName, Text, Version, SPDX.License) -> FloraHTML
-packageListItem (namespace, packageName, synopsis, version, license) = do
+packageListItem :: (Namespace, PackageName, Text, Version, SPDX.License, Vector Text) -> FloraHTML
+packageListItem (namespace, packageName, synopsis, version, license, extraData) = do
   let href = href_ ("/packages/" <> display namespace <> "/" <> display packageName)
   li_ [class_ "package-list-item"] $
     a_ [href, class_ ""] $ do
@@ -38,9 +38,13 @@ packageListItem (namespace, packageName, synopsis, version, license) = do
       p_ [class_ "package-list-item__synopsis"] $ toHtml synopsis
       div_ [class_ "package-list-item__metadata"] $ do
         span_ [class_ "package-list-item__license"] $ do
-          licenseIcon
+          Icon.license
           toHtml license
         span_ [class_ "package-list-item__version"] $ "v" <> toHtml version
+        Vector.forM_ extraData $ \ed ->
+          span_ [class_ "package-list-item__extra_data"] $ do
+            Icon.terminal
+            toHtml ed
 
 requirementListItem :: ComponentDependencies -> FloraHTML
 requirementListItem allComponentDeps =
@@ -77,7 +81,7 @@ componentListItems DependencyInfo{namespace, name = packageName, latestSynopsis,
       p_ [class_ "package-list-item__synopsis"] $ toHtml latestSynopsis
       div_ [class_ "package-list-item__metadata"] $ do
         span_ [class_ "package-list-item__license"] $ do
-          licenseIcon
+          Icon.license
           toHtml latestLicense
         displayVersionRange requirement
 
@@ -86,8 +90,3 @@ displayVersionRange versionRange =
   if versionRange == ">=0"
     then ""
     else span_ [class_ "package-list-item__version-range"] $ toHtml versionRange
-
-licenseIcon :: FloraHTML
-licenseIcon =
-  svg_ [xmlns_ "http://www.w3.org/2000/svg", viewBox_ "0 0 20 20", fill_ "currentColor", class_ "license-icon"] $
-    path_ [fill_rule_ "evenodd", d_ "M10 2a.75.75 0 01.75.75v.258a33.186 33.186 0 016.668.83.75.75 0 01-.336 1.461 31.28 31.28 0 00-1.103-.232l1.702 7.545a.75.75 0 01-.387.832A4.981 4.981 0 0115 14c-.825 0-1.606-.2-2.294-.556a.75.75 0 01-.387-.832l1.77-7.849a31.743 31.743 0 00-3.339-.254v11.505a20.01 20.01 0 013.78.501.75.75 0 11-.339 1.462A18.558 18.558 0 0010 17.5c-1.442 0-2.845.165-4.191.477a.75.75 0 01-.338-1.462 20.01 20.01 0 013.779-.501V4.509c-1.129.026-2.243.112-3.34.254l1.771 7.85a.75.75 0 01-.387.83A4.98 4.98 0 015 14a4.98 4.98 0 01-2.294-.556.75.75 0 01-.387-.832L4.02 5.067c-.37.07-.738.148-1.103.232a.75.75 0 01-.336-1.462 32.845 32.845 0 016.668-.829V2.75A.75.75 0 0110 2zM5 7.543L3.92 12.33a3.499 3.499 0 002.16 0L5 7.543zm10 0l-1.08 4.787a3.498 3.498 0 002.16 0L15 7.543z", clip_rule_ "evenodd"]

--- a/src/web/FloraWeb/Pages/Templates/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Packages.hs
@@ -35,8 +35,8 @@ import Flora.Model.Package
 import Flora.Model.Release.Types
 import Flora.Model.Requirement
 import Flora.Search (SearchAction (..))
-import FloraWeb.Components.Icons
-import FloraWeb.Components.PackageListItem (licenseIcon, packageListItem, requirementListItem)
+import FloraWeb.Components.Icons qualified as Icon
+import FloraWeb.Components.PackageListItem (packageListItem, requirementListItem)
 import FloraWeb.Components.PaginationNav (paginationNav)
 import FloraWeb.Components.Pill (customBuildType)
 import FloraWeb.Components.Utils
@@ -66,9 +66,9 @@ presentationHeaderForSubpage namespace packageName release target numberOfPackag
   div_ [class_ "page-title"] $ h1_ [class_ ""] $ do
     span_ [class_ "headline"] $ do
       displayNamespace namespace
-      chevronRightOutline
+      Icon.chevronRightOutline
       linkToPackageWithVersion namespace packageName release.version
-      chevronRightOutline
+      Icon.chevronRightOutline
       toHtml (display target)
   p_ [class_ "synopsis"] $
     span_ [class_ "version"] $
@@ -85,9 +85,9 @@ presentationHeaderForVersions namespace packageName numberOfReleases = div_ [cla
   div_ [class_ "page-title"] $ h1_ [class_ ""] $ do
     span_ [class_ "headline"] $ do
       displayNamespace namespace
-      chevronRightOutline
+      Icon.chevronRightOutline
       linkToPackage namespace packageName
-      chevronRightOutline
+      Icon.chevronRightOutline
       toHtml (display Versions)
   p_ [class_ "synopsis"] $
     span_ [class_ "version"] $
@@ -116,6 +116,7 @@ showDependents namespace packageName release count packagesInfo currentPage =
               , dep.latestSynopsis
               , dep.latestVersion
               , dep.latestLicense
+              , Vector.empty
               )
         )
     when (count > 30) $
@@ -157,7 +158,7 @@ versionListItem namespace packageName release = do
         div_ [class_ "package-list-item__metadata"] $
           span_ [class_ "package-list-item__license"] $
             do
-              licenseIcon
+              Icon.license
               toHtml release.license
 
 -- | Render a list of package informations
@@ -172,10 +173,10 @@ packageListing mExactMatchItems packages =
     whenJust mExactMatchItems $ \exactMatchItems ->
       forM_ exactMatchItems $ \em ->
         div_ [class_ "exact-match"] $
-          packageListItem (em.namespace, em.name, em.synopsis, em.version, em.license)
+          packageListItem (em.namespace, em.name, em.synopsis, em.version, em.license, em.extraData)
     Vector.forM_
       packages
-      ( \PackageInfo{..} -> packageListItem (namespace, name, synopsis, version, license)
+      ( \PackageInfo{..} -> packageListItem (namespace, name, synopsis, version, license, extraData)
       )
 
 requirementListing :: ComponentDependencies -> FloraHTML
@@ -295,7 +296,7 @@ displayVersions namespace packageName versions numberOfReleases =
                         ("Revised on " <> display (Time.formatTime defaultTimeLocale "%a, %_d %b %Y, %R %EZ" revisionDate))
                     , class_ "revised-date"
                     ]
-                    pen
+                    Icon.pen
 
 displayDependencies
   :: (Namespace, PackageName, Version)
@@ -450,7 +451,7 @@ displayPackageFlags (ReleaseFlags packageFlags) =
         [ dataText_ "Use the -f option with cabal commands to enable flags"
         , class_ "instruction-tooltip"
         ]
-        usageInstructionTooltip
+        Icon.usageInstructionTooltip
       ul_ [class_ "package-flags"] $
         Vector.forM_ packageFlags displayPackageFlag
 

--- a/src/web/FloraWeb/Pages/Templates/Screens/Search.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Search.hs
@@ -21,7 +21,13 @@ showAllPackages count currentPage packagesInfo = do
     div_ [class_ ""] $ packageListing Nothing packagesInfo
     paginationNav count currentPage ListAllPackages
 
-showAllPackagesInNamespace :: Namespace -> Text -> Word -> Positive Word -> Vector PackageInfo -> FloraHTML
+showAllPackagesInNamespace
+  :: Namespace
+  -> Text
+  -> Word
+  -> Positive Word
+  -> Vector PackageInfo
+  -> FloraHTML
 showAllPackagesInNamespace namespace description count currentPage packagesInfo = do
   div_ [class_ "container"] $ do
     presentationHeader (display namespace) description count
@@ -43,3 +49,19 @@ showResults searchString count currentPage exactMatches results = do
     packageListing (Just exactMatches) results
     when (count > 30) $
       paginationNav count currentPage (SearchPackages searchString)
+
+showExecutableResults
+  :: Text
+  -> Word
+  -> Positive Word
+  -> Vector PackageInfo
+  -- ^ Exact matches
+  -> Vector PackageInfo
+  -- ^ Results
+  -> FloraHTML
+showExecutableResults executableName count currentPage exactMatches results = do
+  div_ [class_ "container"] $ do
+    presentationHeader executableName "" count
+    packageListing (Just exactMatches) results
+    when (count > 30) $
+      paginationNav count currentPage (SearchExecutable executableName)

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -146,25 +146,8 @@ testNoSelfDependent :: TestEff ()
 testNoSelfDependent = do
   results <- Query.getAllPackageDependents (Namespace "haskell") (PackageName "text")
   let resultSet = Set.fromList . fmap (view #name) $ Vector.toList results
-  assertEqual
-    ( Set.fromList
-        [ PackageName "Cabal"
-        , PackageName "co-log"
-        , PackageName "flora"
-        , PackageName "hashable"
-        , PackageName "jose"
-        , PackageName "parsec"
-        , PackageName "pg-entity"
-        , PackageName "relude"
-        , PackageName "saturn"
-        , PackageName "semigroups"
-        , PackageName "servant-server"
-        , PackageName "swarm"
-        , PackageName "text-display"
-        , PackageName "xml"
-        ]
-    )
-    resultSet
+  assertBool
+    (Set.notMember (PackageName "text") resultSet)
 
 testBytestringDependencies :: TestEff ()
 testBytestringDependencies = do

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -153,7 +153,6 @@ testNoSelfDependent = do
         , PackageName "flora"
         , PackageName "hashable"
         , PackageName "jose"
-        , PackageName "ouroboros-network"
         , PackageName "parsec"
         , PackageName "pg-entity"
         , PackageName "relude"

--- a/test/Flora/SearchSpec.hs
+++ b/test/Flora/SearchSpec.hs
@@ -14,6 +14,7 @@ spec =
     , testThis "Parsing of \"in:<@namespace> <packagename>\" modifier" testParsingNamespacePackageModifier
     , testThis "Parsing of \"in:<@namespace>\" modifier" testParsingNamespaceModifier
     , testThis "Parsing of a query containing a modifier" testParsingQueryContainingModifier
+    , testThis "Parsing of \"exe:flora-cli\" search modifier" testParsingExecutableSearch
     ]
 
 testParsingDependsSearchModifier :: TestEff ()
@@ -42,4 +43,11 @@ testParsingQueryContainingModifier = do
   let result = parseSearchQuery "bah blah blah depends:@haskell/base"
   assertEqual
     (Just (SearchPackages "bah blah blah depends:@haskell/base"))
+    result
+
+testParsingExecutableSearch :: TestEff ()
+testParsingExecutableSearch = do
+  let result = parseSearchQuery "exe:flora-cli"
+  assertEqual
+    (Just (SearchExecutable "flora-cli"))
     result

--- a/test/Flora/TestUtils.hs
+++ b/test/Flora/TestUtils.hs
@@ -51,6 +51,7 @@ module Flora.TestUtils
   )
 where
 
+import Control.Concurrent (threadDelay)
 import Control.Exception (throw)
 import Control.Monad (void)
 import Control.Monad.Catch
@@ -131,11 +132,12 @@ importAllPackages fixtures = do
     fixtures.hackageUser.userId
     ("hackage", "https://hackage.haskell.org")
     "./test/fixtures/Cabal/hackage"
-
   importAllFilesInRelativeDirectory
     fixtures.hackageUser.userId
     ("cardano", "https://input-output-hk.github.io/cardano-haskell-packages")
     "./test/fixtures/Cabal/cardano"
+
+  liftIO $ threadDelay 20000
 
 runTestEff :: TestEff a -> Pool Connection -> PoolConfig -> IO a
 runTestEff comp pool poolCfg = runEff $


### PR DESCRIPTION
## Proposed changes

This PR introduces the `exe:` search modifier, which brings up the packages with exact or very similar names.

![image](https://github.com/flora-pm/flora-server/assets/15848443/18191d42-55aa-4be6-818b-165402034ef8)


## Contributor checklist

- [x] My PR is related to [FLORA-62](https://plane.sh/flora-pm/f5cfae69-05d7-46ff-94d5-c605ecbc2073?board=list&peekId=35f93f3f-f3d2-4a07-82c9-1f838da0a22c)
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
