### PR TITLE
[NO-ISSUE] Improve medium-sized layout on package detail page

### DIFF
--- a/assets/css/2-components/1-navbar.css
+++ b/assets/css/2-components/1-navbar.css
@@ -100,6 +100,10 @@
   #navbar-search-package-name {
     padding-left: 20px;
   }
+
+  .navbar-themeBtn {
+    flex-shrink: 0;
+  }
 }
 
 @media (max-width: 48rem) {

--- a/assets/css/3-screens/1-package/1-package.css
+++ b/assets/css/3-screens/1-package/1-package.css
@@ -47,10 +47,14 @@
 }
 
 .package-body {
+  --package-layout-gap: 10px;
+
   justify-content: center;
   display: grid;
-  grid-template-columns: 25% 1fr 25%;
-  gap: 10px;
+  grid-template-columns:
+    25% minmax(calc(50% - (var(--package-layout-gap) * 2)), 1fr)
+    25%;
+  gap: var(--package-layout-gap);
 
   > * {
     grid-row-start: 1;

--- a/assets/css/3-screens/1-package/4-compiler-badge.css
+++ b/assets/css/3-screens/1-package/4-compiler-badge.css
@@ -1,7 +1,10 @@
 ul.compiler-badges {
   list-style: none;
   display: grid;
-  grid-template-columns: repeat(3, 80px);
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(min(calc(1.2em + 6ch), 80px), 1fr)
+  ); /* FIXME: Kinda magic numbers soup. Should be improved */
 
   li {
     margin-left: 4px;

--- a/src/web/FloraWeb/Components/Navbar.hs
+++ b/src/web/FloraWeb/Components/Navbar.hs
@@ -139,7 +139,7 @@ themeToggle = do
   let moonIcon = do
         img_ [src_ "/static/icons/moon.svg", class_ "h-6 w-6"]
 
-  let buttonBaseClasses = "p-2 m-4 md:m-0 rounded-md inline-flex items-center bg-slate-200"
+  let buttonBaseClasses = "navbar-themeBtn p-2 m-4 md:m-0 rounded-md inline-flex items-center bg-slate-200"
 
   button_
     [ xOn_ "click" "theme = 'light'; menuOpen = false"


### PR DESCRIPTION
## Proposed changes

1. Readme area is shrinkable
2. Release tag on the right have adjustable width
3. Theme button in the header doesn't shrink on itself anymore


## Screenshots

**Before**

<img width="1130" alt="Screenshot 2024-09-01 at 18 26 49" src="https://github.com/user-attachments/assets/f7d841e8-5182-4440-ab0e-dffdd6b51dca">

---

**After**

<img width="1131" alt="Screenshot 2024-09-01 at 18 27 02" src="https://github.com/user-attachments/assets/b70aa503-1efc-4936-a025-da2cb96630ff">

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
