### PR TITLE
Specify Yarn as the package manager in package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -39,5 +39,6 @@
     "@docusaurus/module-type-aliases": "^3.1.1",
     "@docusaurus/preset-classic": "^3.1.1",
     "csslint": "^1.0.5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION

## Proposed changes

It have been automatically added by Yarn (runed in v1.22.22) when I've started the `watch-assets` task so, I think it should be added to the code base.

cf. https://yarnpkg.com/configuration/manifest#packageManager

## Contributor checklist

- [x] ~~My PR is related to \<insert ticket number>~~ (no issue)
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] ~~I have updated documentation in `./docs/docs` if a public feature has a behaviour change~~ no behaviour change
