### PR TITLE
[NO-ISSUE] Specify Yarn as the package manager in documentation's package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -53,5 +53,6 @@
   },
   "engines": {
     "node": ">=16.14"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Proposed changes

I've forgot about the documentation's package.json when I made the PR #581  😬

## Contributor checklist

- [x] My PR is related to #581 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] ~~I have updated documentation in `./docs/docs` if a public feature has a behaviour change~~ No needed
