### PR TITLE
[NO-ISSUE] Add semantic label for light/dark theme toggle button

### DIFF
--- a/src/web/FloraWeb/Components/Navbar.hs
+++ b/src/web/FloraWeb/Components/Navbar.hs
@@ -134,22 +134,24 @@ adminLink _ _ = ""
 themeToggle :: FloraHTML
 themeToggle = do
   let sunIcon = do
-        img_ [src_ "/static/icons/sun.svg", class_ "h-6 w-6 invert"]
+        img_ [src_ "/static/icons/sun.svg", class_ "h-6 w-6 invert", alt_ ""]
 
   let moonIcon = do
-        img_ [src_ "/static/icons/moon.svg", class_ "h-6 w-6"]
+        img_ [src_ "/static/icons/moon.svg", class_ "h-6 w-6", alt_ ""]
 
   let buttonBaseClasses = "navbar-themeBtn p-2 m-4 md:m-0 rounded-md inline-flex items-center bg-slate-200"
 
   button_
     [ xOn_ "click" "theme = 'light'; menuOpen = false"
     , class_ $ "theme-button--light " <> buttonBaseClasses
+    , ariaLabel_ "Switch to light theme"
     ]
     sunIcon
 
   button_
     [ xOn_ "click" "theme = 'dark'; menuOpen = false"
     , class_ $ "theme-button--dark " <> buttonBaseClasses
+    , ariaLabel_ "Switch to dark theme"
     ]
     moonIcon
 

--- a/src/web/FloraWeb/Components/Utils.hs
+++ b/src/web/FloraWeb/Components/Utils.hs
@@ -31,6 +31,10 @@ defaultLinkOptions =
     , childNode = mempty
     }
 
+-- Standard WAI-ARIA attributes for accessibility purpose
+ariaLabel_ :: Text -> Attribute
+ariaLabel_ = makeAttribute "aria-label"
+
 -- Prefer these ones as they are integrated with AlpineJS
 ariaControls_ :: Text -> Attribute
 ariaControls_ = makeAttribute ":aria-controls"


### PR DESCRIPTION
## Proposed changes

- Add missing (empty) alt attribute on the theme toggle's images
- Add a semantic/accessible text label (with an `aria-label` attribute)

I manually added the aria-label attribute but since more ARIA attribute should probably added in the future, maybe [a package](https://hackage.haskell.org/package/lucid-aria) making all the ARIA attributes globally available into lucid templates could be an idea.

## Contributor checklist

- [x] ~~My PR is related to \<insert ticket number>~~
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] ~~I have updated documentation in `./docs/docs` if a public feature has a behaviour change~~ Not needed
