### PR TITLE
[NO-ISSUE] Avoid category cards from overflowing

### DIFF
--- a/assets/css/3-screens/2-categories.css
+++ b/assets/css/3-screens/2-categories.css
@@ -41,8 +41,6 @@
 		padding-bottom: 0.5rem;
 		padding-left: 2rem;
 		padding-right: 2rem;
-		width: 400px;
-		height: 100px;
 	}
 
 	.category-card:hover {


### PR DESCRIPTION
## Proposed changes

Remove hard-coded size (400x100px) to just let the cards content and grid container do the job

### Before
![Screenshot 2024-09-14 at 15 47 31](https://github.com/user-attachments/assets/cd7b9b38-c968-4c2b-bf8c-f883ff717a8a)
### After
![Screenshot 2024-09-14 at 15 47 42](https://github.com/user-attachments/assets/e41b70ed-1e8a-484b-a24e-a1d71ed69754)

## Contributor checklist

- [x] ~~My PR is related to \<insert ticket number>~~ 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] ~~I have updated documentation in `./docs/docs` if a public feature has a behaviour change~~ Not needed
