### PR TITLE
[NO-ISSUE] Fix "Start with Cabal" link

### DIFF
--- a/src/web/FloraWeb/Pages/Templates/Screens/Home.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Home.hs
@@ -32,7 +32,7 @@ buttons =
       h2_
         [class_ "category-card__name"]
         "Install Haskell"
-    a_ [class_ "button", href_ "https://cabal.readthedocs.io/en/stable/intro.html"] $ do
+    a_ [class_ "button", href_ "https://cabal.readthedocs.io/en/stable/getting-started.html"] $ do
       h2_
         [class_ "category-card__name"]
         "Start with Cabal"


### PR DESCRIPTION
## Proposed changes

Update link to Cabal's documentation on the homepage: 
Replacing: https://cabal.readthedocs.io/en/stable/intro.html (404) to https://cabal.readthedocs.io/en/stable/getting-started.html

## Contributor checklist

- ~~[ ] My PR is related to \<insert ticket number>~~ 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- ~~[ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change~~ Not necessary
