### PR TITLE
Add CI check for missing FK indexes

### DIFF
--- a/.github/workflows/check-missing-fk-indexes.sh
+++ b/.github/workflows/check-missing-fk-indexes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output="$(psql "$FLORA_DB_CONNSTRING" -f scripts/missing-fk-indexes.sql 2>&1 > /dev/null)"
+
+if [[ "$output" == *"Missing FK indexes"* ]]
+then
+    echo "Missing FK index! Run \`psql \"\$FLORA_DB_CONNSTRING\" -f scripts/missing-fk-indexes.sql\` and apply them"
+    exit 1
+else
+    exit 0
+fi

--- a/.github/workflows/missing-fk-indexes.yml
+++ b/.github/workflows/missing-fk-indexes.yml
@@ -1,4 +1,4 @@
-name: Backend tests
+name: Missing FK Indexes
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     branches: ["main", "development"]
 
 concurrency:
-  group: backend-${{ github.ref_name }}
+  group: missing-kf-indexes-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
           ubuntu-version: "latest"
           version: 0.1.7.1
 
-  Backend_tests:
+  index-check:
     needs: generateMatrix
     runs-on: ${{ matrix.os }}
     strategy:
@@ -56,12 +56,6 @@ jobs:
         ghc-version: "${{ matrix.ghc }}"
         cabal-version: "latest"
 
-    - uses: actions/setup-node@v4
-      with:
-        node-version: "18"
-        cache: "yarn"
-        cache-dependency-path: assets/yarn.lock
-
     - name: Configure environment
       run: |
         ./.github/workflows/setup.sh
@@ -77,6 +71,7 @@ jobs:
         echo "${FLORA_DB_HOST}:${FLORA_DB_PORT}:${FLORA_DB_DATABASE}:${FLORA_DB_USER}:${FLORA_DB_PASSWORD}" > .pgpass
         cat ~/.pgpass
         cabal update
+
     - name: Cache
       uses: actions/cache@v4.0.2
       with:
@@ -84,21 +79,19 @@ jobs:
         key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('./.plan.json') }}
         restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
 
-    - name: Build
+
+    - name: Migrate
       run: |
         cabal install postgresql-migration
-        make soufflé
-        make assets-deps
-        make build-assets
-        make build
-    - name: Test
-      run: |
         set -x
         source ./environment.ci.sh
         createdb -h "${FLORA_DB_HOST}" -p "${FLORA_DB_PORT}" -U "${FLORA_DB_USER}" -w "${FLORA_DB_DATABASE}"
         migrate init "${FLORA_DB_CONNSTRING}"
         migrate migrate "${FLORA_DB_CONNSTRING}" migrations
-        cabal run -- flora-cli create-user --username "hackage-user" --email "tech@flora.pm" --password "foobar2000"
-        make test
       env:
         PGPASSWORD: "postgres"
+
+    - name: Check
+      run: |
+        source ./environment.ci.sh
+        .github/workflows/check-missing-fk-indexes.sh

--- a/changelog.d/605
+++ b/changelog.d/605
@@ -1,0 +1,2 @@
+synopsis: Add CI check for missing FK indexes
+prs: #605

--- a/environment.ci.sh
+++ b/environment.ci.sh
@@ -10,5 +10,4 @@ export FLORA_DB_USER="postgres"
 export FLORA_LOGGING_DESTINATION="stdout"
 export FLORA_HTTP_PORT=8083
 
-export FLORA_DB_CONNSTRING="host=${FLORA_DB_HOST} dbname=${FLORA_DB_DATABASE}\
-  user=${FLORA_DB_USER} password=${FLORA_DB_PASSWORD}"
+export FLORA_DB_CONNSTRING="host=${FLORA_DB_HOST} dbname=${FLORA_DB_DATABASE} user=${FLORA_DB_USER} password=${FLORA_DB_PASSWORD}"

--- a/migrations/20241004135653_missing_fk_indexes.sql
+++ b/migrations/20241004135653_missing_fk_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX user_organisation_organisation_id_fkey ON user_organisation(organisation_id);
+CREATE INDEX user_organisation_user_id_fkey ON user_organisation(user_id);
+CREATE INDEX packages_owner_id_fkey ON packages(owner_id);
+CREATE INDEX package_publishers_package_id_fkey ON package_publishers(package_id);
+CREATE INDEX package_publishers_user_id_fkey ON package_publishers(user_id);
+CREATE INDEX repository ON releases(repository);
+CREATE INDEX requirements_package_id_fkey ON requirements(package_id);
+CREATE INDEX package_categories_category_id_fkey ON package_categories(category_id);

--- a/scripts/missing-fk-indexes.sql
+++ b/scripts/missing-fk-indexes.sql
@@ -1,0 +1,54 @@
+-- ® Marc Cousin 2024
+DO
+$$
+DECLARE
+    numversion int;
+    indkeysfilter varchar;
+    indexquery varchar;
+    missing_indexes varchar;
+BEGIN
+    SELECT INTO numversion setting FROM pg_settings WHERE name = 'server_version_num';
+    -- manage covering indexes in PG 11
+    IF numversion >= 110000 THEN
+        RAISE DEBUG 'numversion %',numversion;
+        indkeysfilter := '((indkey::int4[])[0:indnkeyatts-1])[1:array_upper(conkey,1)]';
+    ELSE
+        indkeysfilter := '((indkey::int4[]))[0:array_upper(conkey,1) - 1]';
+    END IF;
+
+
+    indexquery := format('
+with not_indexed_constraints as (
+        select conname, conrelid::regclass as tablename, conkey
+        from pg_constraint
+        where contype = ''f''
+          and not exists (
+                 select 1
+                 from pg_index
+                 where indrelid=conrelid
+                   and %s @> conkey::int4[]
+                   and %s <@ conkey::int4[]
+                   and indpred is null
+              )
+          and not exists (
+                 select 1 from pg_depend
+                 where objid = conrelid and classid = ''pg_class''::regclass and deptype = ''e''
+          )
+     ),
+     unnested_constraints as (
+        select conname, tablename, unnest.* FROM not_indexed_constraints,unnest(conkey) with ordinality),
+     missing_indexes as (
+SELECT ''CREATE INDEX CONCURRENTLY '' || conname || '' ON '' || tablename::text || ''('' ||
+       string_agg(quote_ident(attname::text), '','' order by ordinality) || '');'' as indexes
+from unnested_constraints
+join  pg_attribute on (unnested_constraints.tablename=pg_attribute.attrelid
+                   and pg_attribute.attnum=unnested_constraints.unnest)
+group by tablename,conname)
+     SELECT string_agg(indexes,E''\n'') as indexes from missing_indexes', indkeysfilter, indkeysfilter);
+
+    EXECUTE indexquery INTO missing_indexes;
+    IF length(missing_indexes) > 0 THEN
+        RAISE 'Missing FK indexes: %',missing_indexes;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This PR adds a CI check to ensure that no index is missing for foreign keys. It's not a known fact that foreign keys do not automatically create indexes, despite their main usage being used for joins.

Shout-out to @marco44.
