### PR TITLE
Add “docker compose stop” task to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,10 @@ docker-build: ## Build and start the container cluster
 docker-up: ## Start the container cluster
 	@docker compose up -d
 
-docker-down: ## Start the container cluster
+docker-stop: ## Stop the container cluster without removing the containers
+	@docker compose stop
+
+docker-down: ## Stop and remove the container cluster
 	@docker compose down
 
 docker-enter: ## Enter the docker environment


### PR DESCRIPTION
Add docker-stop command to Makefile, improve comments

## Proposed changes
- Add a `docker-stop` command to only stop containers without removing them
- Clarify the comments/documentation

## Contributor checklist

- [x] My PR is related to #604
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- ~~[ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)~~ (no impact)
- ~~[ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change~~ (no impact)