### PR TITLE
Store affected version ranges by version instead of release ID

### DIFF
--- a/migrations/20241014081932_create_affected_version_ranges.sql
+++ b/migrations/20241014081932_create_affected_version_ranges.sql
@@ -1,15 +1,15 @@
 CREATE TABLE IF NOT EXISTS affected_version_ranges (
     affected_version_id uuid PRIMARY KEY
   , affected_package_id uuid REFERENCES affected_packages NOT NULL
-  , introduced_version uuid REFERENCES releases (release_id) NOT NULL
-  , fixed_version uuid REFERENCES releases (release_id)
+  , introduced_version int[] NOT NULL
+  , fixed_version int[]
 );
 
 CREATE INDEX affected_version_ranges_affected_package_id_fkey
   ON affected_version_ranges (affected_package_id);
 
-CREATE INDEX affected_version_ranges_introduced_version_fkey
+CREATE INDEX affected_version_ranges_introduced_version
   ON affected_version_ranges (introduced_version);
 
-CREATE INDEX affected_version_ranges_fixed_version_fkey
+CREATE INDEX affected_version_ranges_fixed_version
   ON affected_version_ranges (fixed_version);

--- a/migrations/20241116223018_add_index_on_release_version.sql
+++ b/migrations/20241116223018_add_index_on_release_version.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON releases (version);

--- a/src/advisories/Advisories/Model/Affected/Types.hs
+++ b/src/advisories/Advisories/Model/Affected/Types.hs
@@ -10,7 +10,7 @@ import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField
 import Database.PostgreSQL.Simple.Newtypes
 import Database.PostgreSQL.Simple.ToField
-import Distribution.Types.VersionRange (VersionRange)
+import Distribution.Version
 import GHC.Generics
 import Security.Advisories.Core.Advisory
 import Security.CVSS (CVSS)
@@ -22,7 +22,6 @@ import Advisories.System.Orphans ()
 import Distribution.Orphans.ConfVar ()
 import Distribution.Orphans.Version ()
 import Flora.Model.Package.Types
-import Flora.Model.Release.Types
 
 newtype AffectedPackageId = AffectedPackageId {getAffectedPackageId :: UUID}
   deriving stock (Generic, Show)
@@ -65,8 +64,8 @@ newtype AffectedVersionId = AffectedVersionId {getAffectedVersionId :: UUID}
 data AffectedVersionRangeDAO = AffectedVersionRangeDAO
   { affectedVersionId :: AffectedVersionId
   , affectedPackageId :: AffectedPackageId
-  , introducedVersion :: ReleaseId
-  , fixedVersion :: Maybe ReleaseId
+  , introducedVersion :: Version
+  , fixedVersion :: Maybe Version
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromRow, ToRow, NFData)


### PR DESCRIPTION
This allows for greater flexiblity when it comes to declared versions that do not appear in the affected package repository

