### PR TITLE
[NO-ISSUE] Fix minor typo in description ('develope' -> 'develop')

### DIFF
--- a/cbits/categorise.dl
+++ b/cbits/categorise.dl
@@ -24,7 +24,7 @@ flora_category("algorithms", "Algorithms", "Algorithms implemented in Haskell, l
 flora_category("audio", "Audio", "Process digital signal, make music").
 flora_category("bioinformatics", "Bioinformatics", "Methods and software for the analysis of biological data").
 flora_category("cloud", "Cloud Computing", "Bindings to Cloud Computing platforms").
-flora_category("command-line", "CLI & TUI tooling", "Libraries to develope command-line interfaces").
+flora_category("command-line", "CLI & TUI tooling", "Libraries to develop command-line interfaces").
 flora_category("compilers-interpreters", "Compilers and Interpreters", "Tooling to create compilers and interpreters").
 flora_category("compression", "Data compression", "Reducing the size of things").
 flora_category("concurrency", "Concurrency", "Concurrent programming techniques and tools").


### PR DESCRIPTION
## Proposed changes

Fix minor typo in description of the `command-line` category. In particular, changed it from 

> Libraries to develope command-line interfaces

to

> Libraries to develop command-line interfaces

## Contributor checklist

- [ ] My PR is related to \<insert ticket number> 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
