### PR TITLE
Use latest release version when computing transitive dependencies

### DIFF
--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -817,10 +817,12 @@ WITH RECURSIVE transitive_dependencies(  dependent_id, dependent_namespace, depe
            INNER JOIN releases AS r2 ON c1.release_id = r2.release_id
            INNER JOIN packages AS p3 ON r2.package_id = p3.package_id
            INNER JOIN packages AS p4 ON r0.package_id = p4.package_id
-           INNER JOIN transitive_dependencies AS t5 ON t5.dependency_id = p3.package_id
+           INNER JOIN latest_versions as l5 ON l5.package_id = p3.package_id
+           INNER JOIN transitive_dependencies AS t6 ON t6.dependency_id = p3.package_id
       WHERE c1.component_type = 'library'
         AND p4.status = 'fully-imported'
-        AND p4.name <> p3.name)
+        AND p4.name <> p3.name
+        AND r2.version = l5.version)
 
    CYCLE dependency_id SET is_cycle TO TRUE DEFAULT FALSE USING path
 

--- a/test/Flora/PackageSpec.hs
+++ b/test/Flora/PackageSpec.hs
@@ -296,20 +296,20 @@ testTransitiveDependencies = do
   dependenciesMap <- Query.getTransitiveDependencies baseComponent.componentId
 
   assertEqual
-    dependenciesMap
     ( Vector.fromList
         [ PackageDependencies
             { namespace = Namespace "haskell"
             , packageName = PackageName "ghc-bignum"
             , requirements =
                 Vector.fromList
-                  [ DependencyVersionRequirement{namespace = Namespace "haskell", packageName = PackageName "ghc-prim", version = ">=0.5.1.0 && <0.9"}
+                  [ DependencyVersionRequirement{namespace = Namespace "haskell", packageName = PackageName "ghc-prim", version = ">=0.5.1.0 && <0.10"}
                   ]
             }
         , PackageDependencies{namespace = Namespace "haskell", packageName = PackageName "base", requirements = Vector.fromList [DependencyVersionRequirement{namespace = Namespace "haskell", packageName = PackageName "ghc-bignum", version = ">=1.0 && <2.0"}, DependencyVersionRequirement{namespace = Namespace "haskell", packageName = PackageName "ghc-prim", version = ">=0.5.1.0 && <0.9"}, DependencyVersionRequirement{namespace = Namespace "haskell", packageName = PackageName "rts", version = ">=1.0 && <1.1"}]}
         , PackageDependencies{namespace = Namespace "haskell", packageName = PackageName "ghc-prim", requirements = Vector.fromList [DependencyVersionRequirement{namespace = Namespace "haskell", packageName = PackageName "rts", version = ">=1.0 && <1.1"}]}
         ]
     )
+    dependenciesMap
 
 testSerialiseDependenciesTree :: TestEff ()
 testSerialiseDependenciesTree = do

--- a/test/fixtures/Cabal/hackage/ghc-bignum-1.1.cabal
+++ b/test/fixtures/Cabal/hackage/ghc-bignum-1.1.cabal
@@ -1,0 +1,123 @@
+cabal-version:       2.0
+name:                ghc-bignum
+version:             1.1
+synopsis:            GHC BigNum library
+license:             BSD3
+license-file:        LICENSE
+author:              Sylvain Henry
+maintainer:          libraries@haskell.org
+bug-reports:         https://gitlab.haskell.org/ghc/ghc/issues/new
+category:            Numeric, Algebra, GHC
+build-type:          Configure
+description:
+    This package provides the low-level implementation of the standard
+    'BigNat', 'Natural' and 'Integer' types.
+
+extra-source-files:
+    aclocal.m4
+    cbits/gmp_wrappers.c
+    changelog.md
+    configure
+    configure.ac
+    config.mk.in
+    include/WordSize.h
+    include/HsIntegerGmp.h.in
+    install-sh
+    ghc-bignum.buildinfo.in
+
+source-repository head
+    type:     git
+    location: https://gitlab.haskell.org/ghc/ghc.git
+    subdir:   libraries/ghc-bignum
+
+
+Flag Native
+    Description: Enable native backend
+    Manual: True
+    Default: False
+
+Flag FFI
+    Description: Enable FFI backend
+    Manual: True
+    Default: False
+
+Flag GMP
+    Description: Enable GMP backend
+    Manual: True
+    Default: False
+
+Flag Check
+    Description: Validate results of the enabled backend against native backend.
+    Manual: True
+    Default: False
+
+library
+
+  -- check that at least one flag is set
+  if !flag(native) && !flag(gmp) && !flag(ffi)
+    buildable: False
+
+  -- check that at most one flag is set
+  if flag(native) && (flag(gmp) || flag(ffi))
+    buildable: False
+  if flag(gmp) && flag(ffi)
+    buildable: False
+
+  default-language:    Haskell2010
+  other-extensions:
+    BangPatterns
+    CPP
+    ExplicitForAll
+    GHCForeignImportPrim
+    MagicHash
+    NegativeLiterals
+    NoImplicitPrelude
+    UnboxedTuples
+    UnliftedFFITypes
+    ForeignFunctionInterface
+
+  build-depends:
+    ghc-prim >= 0.5.1.0 && < 0.8
+
+  hs-source-dirs: src/
+  include-dirs: include/
+  ghc-options: -Wall
+  cc-options: -std=c99 -Wall
+
+  -- GHC has wired-in IDs from the ghc-bignum package. Hence the unit-id
+  -- of the package should not contain the version: i.e. it must be
+  -- "ghc-bignum" and not "ghc-bignum-1.0".
+  ghc-options: -this-unit-id ghc-bignum
+
+  include-dirs: include
+
+  if flag(gmp)
+      cpp-options: -DBIGNUM_GMP
+      other-modules:
+         GHC.Num.Backend.GMP
+      c-sources:
+         cbits/gmp_wrappers.c
+
+  if flag(ffi)
+      cpp-options: -DBIGNUM_FFI
+      other-modules:
+         GHC.Num.Backend.FFI
+
+  if flag(native)
+      cpp-options: -DBIGNUM_NATIVE
+
+  if flag(check)
+      cpp-options: -DBIGNUM_CHECK
+      other-modules:
+         GHC.Num.Backend.Check
+
+
+  exposed-modules:
+    GHC.Num.Primitives
+    GHC.Num.WordArray
+    GHC.Num.BigNat
+    GHC.Num.Backend
+    GHC.Num.Backend.Selected
+    GHC.Num.Backend.Native
+    GHC.Num.Natural
+    GHC.Num.Integer

--- a/test/fixtures/Cabal/hackage/ghc-bignum-1.2.cabal
+++ b/test/fixtures/Cabal/hackage/ghc-bignum-1.2.cabal
@@ -1,0 +1,123 @@
+cabal-version:       2.0
+name:                ghc-bignum
+version:             1.2
+synopsis:            GHC BigNum library
+license:             BSD3
+license-file:        LICENSE
+author:              Sylvain Henry
+maintainer:          libraries@haskell.org
+bug-reports:         https://gitlab.haskell.org/ghc/ghc/issues/new
+category:            Numeric, Algebra, GHC
+build-type:          Configure
+description:
+    This package provides the low-level implementation of the standard
+    'BigNat', 'Natural' and 'Integer' types.
+
+extra-source-files:
+    aclocal.m4
+    cbits/gmp_wrappers.c
+    changelog.md
+    configure
+    configure.ac
+    config.mk.in
+    include/WordSize.h
+    include/HsIntegerGmp.h.in
+    install-sh
+    ghc-bignum.buildinfo.in
+
+source-repository head
+    type:     git
+    location: https://gitlab.haskell.org/ghc/ghc.git
+    subdir:   libraries/ghc-bignum
+
+
+Flag Native
+    Description: Enable native backend
+    Manual: True
+    Default: False
+
+Flag FFI
+    Description: Enable FFI backend
+    Manual: True
+    Default: False
+
+Flag GMP
+    Description: Enable GMP backend
+    Manual: True
+    Default: False
+
+Flag Check
+    Description: Validate results of the enabled backend against native backend.
+    Manual: True
+    Default: False
+
+library
+
+  -- check that at least one flag is set
+  if !flag(native) && !flag(gmp) && !flag(ffi)
+    buildable: False
+
+  -- check that at most one flag is set
+  if flag(native) && (flag(gmp) || flag(ffi))
+    buildable: False
+  if flag(gmp) && flag(ffi)
+    buildable: False
+
+  default-language:    Haskell2010
+  other-extensions:
+    BangPatterns
+    CPP
+    ExplicitForAll
+    GHCForeignImportPrim
+    MagicHash
+    NegativeLiterals
+    NoImplicitPrelude
+    UnboxedTuples
+    UnliftedFFITypes
+    ForeignFunctionInterface
+
+  build-depends:
+    ghc-prim >= 0.5.1.0 && < 0.9
+
+  hs-source-dirs: src/
+  include-dirs: include/
+  ghc-options: -Wall
+  cc-options: -std=c99 -Wall
+
+  -- GHC has wired-in IDs from the ghc-bignum package. Hence the unit-id
+  -- of the package should not contain the version: i.e. it must be
+  -- "ghc-bignum" and not "ghc-bignum-1.0".
+  ghc-options: -this-unit-id ghc-bignum
+
+  include-dirs: include
+
+  if flag(gmp)
+      cpp-options: -DBIGNUM_GMP
+      other-modules:
+         GHC.Num.Backend.GMP
+      c-sources:
+         cbits/gmp_wrappers.c
+
+  if flag(ffi)
+      cpp-options: -DBIGNUM_FFI
+      other-modules:
+         GHC.Num.Backend.FFI
+
+  if flag(native)
+      cpp-options: -DBIGNUM_NATIVE
+
+  if flag(check)
+      cpp-options: -DBIGNUM_CHECK
+      other-modules:
+         GHC.Num.Backend.Check
+
+
+  exposed-modules:
+    GHC.Num.Primitives
+    GHC.Num.WordArray
+    GHC.Num.BigNat
+    GHC.Num.Backend
+    GHC.Num.Backend.Selected
+    GHC.Num.Backend.Native
+    GHC.Num.Natural
+    GHC.Num.Integer

--- a/test/fixtures/Cabal/hackage/ghc-bignum-1.3.cabal
+++ b/test/fixtures/Cabal/hackage/ghc-bignum-1.3.cabal
@@ -1,0 +1,123 @@
+cabal-version:       2.0
+name:                ghc-bignum
+version:             1.3
+synopsis:            GHC BigNum library
+license:             BSD3
+license-file:        LICENSE
+author:              Sylvain Henry
+maintainer:          libraries@haskell.org
+bug-reports:         https://gitlab.haskell.org/ghc/ghc/issues/new
+category:            Numeric, Algebra, GHC
+build-type:          Configure
+description:
+    This package provides the low-level implementation of the standard
+    'BigNat', 'Natural' and 'Integer' types.
+
+extra-source-files:
+    aclocal.m4
+    cbits/gmp_wrappers.c
+    changelog.md
+    configure
+    configure.ac
+    config.mk.in
+    include/WordSize.h
+    include/HsIntegerGmp.h.in
+    install-sh
+    ghc-bignum.buildinfo.in
+
+source-repository head
+    type:     git
+    location: https://gitlab.haskell.org/ghc/ghc.git
+    subdir:   libraries/ghc-bignum
+
+
+Flag Native
+    Description: Enable native backend
+    Manual: True
+    Default: False
+
+Flag FFI
+    Description: Enable FFI backend
+    Manual: True
+    Default: False
+
+Flag GMP
+    Description: Enable GMP backend
+    Manual: True
+    Default: False
+
+Flag Check
+    Description: Validate results of the enabled backend against native backend.
+    Manual: True
+    Default: False
+
+library
+
+  -- check that at least one flag is set
+  if !flag(native) && !flag(gmp) && !flag(ffi)
+    buildable: False
+
+  -- check that at most one flag is set
+  if flag(native) && (flag(gmp) || flag(ffi))
+    buildable: False
+  if flag(gmp) && flag(ffi)
+    buildable: False
+
+  default-language:    Haskell2010
+  other-extensions:
+    BangPatterns
+    CPP
+    ExplicitForAll
+    GHCForeignImportPrim
+    MagicHash
+    NegativeLiterals
+    NoImplicitPrelude
+    UnboxedTuples
+    UnliftedFFITypes
+    ForeignFunctionInterface
+
+  build-depends:
+    ghc-prim >= 0.5.1.0 && < 0.10
+
+  hs-source-dirs: src/
+  include-dirs: include/
+  ghc-options: -Wall
+  cc-options: -std=c99 -Wall
+
+  -- GHC has wired-in IDs from the ghc-bignum package. Hence the unit-id
+  -- of the package should not contain the version: i.e. it must be
+  -- "ghc-bignum" and not "ghc-bignum-1.0".
+  ghc-options: -this-unit-id ghc-bignum
+
+  include-dirs: include
+
+  if flag(gmp)
+      cpp-options: -DBIGNUM_GMP
+      other-modules:
+         GHC.Num.Backend.GMP
+      c-sources:
+         cbits/gmp_wrappers.c
+
+  if flag(ffi)
+      cpp-options: -DBIGNUM_FFI
+      other-modules:
+         GHC.Num.Backend.FFI
+
+  if flag(native)
+      cpp-options: -DBIGNUM_NATIVE
+
+  if flag(check)
+      cpp-options: -DBIGNUM_CHECK
+      other-modules:
+         GHC.Num.Backend.Check
+
+
+  exposed-modules:
+    GHC.Num.Primitives
+    GHC.Num.WordArray
+    GHC.Num.BigNat
+    GHC.Num.Backend
+    GHC.Num.Backend.Selected
+    GHC.Num.Backend.Native
+    GHC.Num.Natural
+    GHC.Num.Integer


### PR DESCRIPTION
The transitive dependencies algorithm can get way too many results if it is not selective about which releases it is allowed to use. For the sake of simplicity, the latest release is always used.

Otherwise, we end up with results that look like:

| dependent_id                         | dependent_name | array_agg                                                                                                                       |
|--------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------|
| 01beb56b-23ed-bc5d-f406-a601954fa8dd | ghc-bignum     | [['haskell', 'ghc-prim', '>=0.5.1.0 && <0.10']]                                                                                 |
| 0e54f361-f8a2-3f12-4490-3a38224d1dee | ghc-bignum     | [['haskell', 'ghc-prim', '>=0.5.1.0 && <0.9']]                                                                                  |
| 2257c012-6479-a89d-c9e2-258dd5fd2910 | base           | [['haskell', 'ghc-bignum', '>=1.0 && <2.0'], ['haskell', 'ghc-prim', '>=0.5.1.0 && <0.9'], ['haskell', 'rts', '>=1.0 && <1.1']] |
| 4bfdf5c0-fe20-9d83-63b0-eef6f7565532 | ghc-prim       | [['haskell', 'rts', '>=1.0 && <1.1']]                                                                                           |
| 7c2f9b85-b4a7-7d17-dde5-3e6ed7468340 | deepseq        | [['haskell', 'array', '>=0.4 && <0.6'], ['haskell', 'base', '>=4.5 && <4.17'], ['haskell', 'ghc-prim', '>=0.2 && <0.3']]        |
| b47f84c1-e8e5-5bf8-6ff1-fbf458d41e94 | array          | [['haskell', 'base', '>=4.9 && <4.14']]                                                                                         |
| bd33972f-5514-9eb5-bbf8-f784bee076c2 | ghc-bignum     | [['haskell', 'ghc-prim', '>=0.5.1.0 && <0.8']]                                                                                  |


Which translates to the following JSON:

```json

{
    "dependencies": [
        {
            "namespace": "haskell",
            "package_name": "ghc-bignum",
            "requirements": [
                {
                    "namespace": "haskell",
                    "package_name": "ghc-prim",
                    "version": ">=0.5.1.0 && <0.10"
                }
            ]
        },
        {
            "namespace": "haskell",
            "package_name": "ghc-bignum",
            "requirements": [
                {
                    "namespace": "haskell",
                    "package_name": "ghc-prim",
                    "version": ">=0.5.1.0 && <0.9"
                }
            ]
        },
        {
            "namespace": "haskell",
            "package_name": "base",
            "requirements": [
                {
                    "namespace": "haskell",
                    "package_name": "ghc-bignum",
                    "version": ">=1.0 && <2.0"
                },
                {
                    "namespace": "haskell",
                    "package_name": "ghc-prim",
                    "version": ">=0.5.1.0 && <0.9"
                },
                {
                    "namespace": "haskell",
                    "package_name": "rts",
                    "version": ">=1.0 && <1.1"
                }
            ]
        },
        {
            "namespace": "haskell",
            "package_name": "ghc-prim",
            "requirements": [
                {
                    "namespace": "haskell",
                    "package_name": "rts",
                    "version": ">=1.0 && <1.1"
                }
            ]
        },
        {
            "namespace": "haskell",
            "package_name": "ghc-bignum",
            "requirements": [
                {
                    "namespace": "haskell",
                    "package_name": "ghc-prim",
                    "version": ">=0.5.1.0 && <0.8"
                }
            ]
        }
    ]
}
```

With this patch, the results are changed to look like this:

```diff
@@ -14,17 +13,6 @@
         },
         {
             "namespace": "haskell",
-            "package_name": "ghc-bignum",
-            "requirements": [
-                {
-                    "namespace": "haskell",
-                    "package_name": "ghc-prim",
-                    "version": ">=0.5.1.0 && <0.9"
-                }
-            ]
-        },
-        {
-            "namespace": "haskell",
             "package_name": "base",
             "requirements": [
                 {
@@ -54,17 +42,6 @@
                     "version": ">=1.0 && <1.1"
                 }
             ]
-        },
-        {
-            "namespace": "haskell",
-            "package_name": "ghc-bignum",
-            "requirements": [
-                {
-                    "namespace": "haskell",
-                    "package_name": "ghc-prim",
-                    "version": ">=0.5.1.0 && <0.8"
-                }
-            ]
         }
     ]
 }
```