### PR TITLE
[FLORA-835] Implement API route for searching packages by name prefix

### DIFF
--- a/changelog.d/865
+++ b/changelog.d/865
@@ -1,0 +1,10 @@
+synopsis: Implement API route for package prefix search
+prs: #873
+issues: #835
+
+description: {
+
+- A new route under /api/experimental/packages/search/:packageNamePrefix is added.
+  It returns a vector of names of packages matching the prefix.
+
+}

--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -19,6 +19,7 @@ module Flora.Model.Package.Query
   , getPackageDependents
   , getPackageDependentsByName
   , getPackageDependentsWithLatestVersion
+  , getPackagesByPrefix
   , getPackagesByNamespace
   , getPackagesFromCategoryWithLatestVersion
   , getRequirements
@@ -86,6 +87,20 @@ getAllPackages = do
     object
       ["duration" .= duration]
   pure result
+
+getPackagesByPrefix :: (DB :> es) => Text -> Eff es (Vector Package)
+getPackagesByPrefix prefix = do
+  let prefixString = prefix <> "%"
+  dbtToEff $ do
+    (result :: Vector Package) <- query Select packagesByPrefixQuery (Only prefixString)
+    pure result
+
+packagesByPrefixQuery :: Query
+packagesByPrefixQuery =
+  [sql|
+  SELECT * FROM "packages"
+  WHERE name LIKE ?
+  |]
 
 getPackagesByNamespace :: DB :> es => Namespace -> Eff es (Vector Package)
 getPackagesByNamespace namespace = dbtToEff $ selectManyByField @Package [field| namespace |] (Only namespace)

--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -19,7 +19,6 @@ module Flora.Model.Package.Query
   , getPackageDependents
   , getPackageDependentsByName
   , getPackageDependentsWithLatestVersion
-  , getPackagesByPrefix
   , getPackagesByNamespace
   , getPackagesFromCategoryWithLatestVersion
   , getRequirements
@@ -87,20 +86,6 @@ getAllPackages = do
     object
       ["duration" .= duration]
   pure result
-
-getPackagesByPrefix :: DB :> es => Text -> Eff es (Vector Package)
-getPackagesByPrefix prefix = do
-  let prefixString = prefix <> "%"
-  dbtToEff $ do
-    (result :: Vector Package) <- query Select packagesByPrefixQuery (Only prefixString)
-    pure result
-
-packagesByPrefixQuery :: Query
-packagesByPrefixQuery =
-  [sql|
-  SELECT * FROM "packages"
-  WHERE name LIKE ?
-  |]
 
 getPackagesByNamespace :: DB :> es => Namespace -> Eff es (Vector Package)
 getPackagesByNamespace namespace = dbtToEff $ selectManyByField @Package [field| namespace |] (Only namespace)

--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -88,7 +88,7 @@ getAllPackages = do
       ["duration" .= duration]
   pure result
 
-getPackagesByPrefix :: (DB :> es) => Text -> Eff es (Vector Package)
+getPackagesByPrefix :: DB :> es => Text -> Eff es (Vector Package)
 getPackagesByPrefix prefix = do
   let prefixString = prefix <> "%"
   dbtToEff $ do

--- a/src/web/FloraWeb/API/Routes/Packages.hs
+++ b/src/web/FloraWeb/API/Routes/Packages.hs
@@ -44,6 +44,8 @@ data API' mode = API'
       :: mode
         :- "search"
           :> Capture "packageNamePrefix" Text
+          :> QueryParam "offset" Word
+          :> QueryParam "limit" Word
           :> GetPackagesByPrefix
   , withPackage
       :: mode

--- a/src/web/FloraWeb/API/Routes/Packages.hs
+++ b/src/web/FloraWeb/API/Routes/Packages.hs
@@ -1,10 +1,10 @@
 module FloraWeb.API.Routes.Packages where
 
+import Data.Text (Text)
+import Data.Vector (Vector)
 import Distribution.Version
 import GHC.Generics
 import Servant
-import Data.Text (Text)
-import Data.Vector (Vector)
 
 import Flora.Model.Package
 import FloraWeb.API.Routes.Packages.Types
@@ -14,20 +14,20 @@ type API = NamedRoutes API'
 type GetPackage =
   Summary "Get information about a package"
     :> Description
-         "Return information about a package and its latest version"
+        "Return information about a package and its latest version"
     :> Get '[JSON] (PackageDTO 0)
 
 type GetVersionedPackage =
   Summary "Get information about a package and version"
     :> Description
-         "Return information about a package and the specified version"
+        "Return information about a package and the specified version"
     :> Capture "version" Version
     :> Get '[JSON] (PackageDTO 0)
 
 type GetPackageDependencies =
   Summary "Get dependencies of a package"
     :> Description
-         "Return dependencies of a package"
+        "Return dependencies of a package"
     :> Capture "version" Version
     :> "dependencies"
     :> QueryFlag "transitive"
@@ -36,7 +36,7 @@ type GetPackageDependencies =
 type GetPackagesByPrefix =
   Summary "Get a list of packages"
     :> Description
-         "Return a list of packages, given a prefix"
+        "Return a list of packages, given a prefix"
     :> Get '[JSON] (Vector PackageName)
 
 data API' mode = API'

--- a/src/web/FloraWeb/API/Routes/Packages.hs
+++ b/src/web/FloraWeb/API/Routes/Packages.hs
@@ -3,6 +3,8 @@ module FloraWeb.API.Routes.Packages where
 import Distribution.Version
 import GHC.Generics
 import Servant
+import Data.Text (Text)
+import Data.Vector (Vector)
 
 import Flora.Model.Package
 import FloraWeb.API.Routes.Packages.Types
@@ -31,8 +33,19 @@ type GetPackageDependencies =
     :> QueryFlag "transitive"
     :> Get '[JSON] (PackageDependenciesDTO 0)
 
+type GetPackagesByPrefix =
+  Summary "Get a list of packages"
+    :> Description
+         "Return a list of packages, given a prefix"
+    :> Get '[JSON] (Vector PackageName)
+
 data API' mode = API'
-  { withPackage
+  { getPackagesByPrefix
+      :: mode
+        :- "search"
+          :> Capture "packageNamePrefix" Text
+          :> GetPackagesByPrefix
+  , withPackage
       :: mode
         :- Capture "namespace" Namespace
           :> Capture "packageName" PackageName

--- a/src/web/FloraWeb/API/Routes/Packages.hs
+++ b/src/web/FloraWeb/API/Routes/Packages.hs
@@ -14,20 +14,20 @@ type API = NamedRoutes API'
 type GetPackage =
   Summary "Get information about a package"
     :> Description
-        "Return information about a package and its latest version"
+         "Return information about a package and its latest version"
     :> Get '[JSON] (PackageDTO 0)
 
 type GetVersionedPackage =
   Summary "Get information about a package and version"
     :> Description
-        "Return information about a package and the specified version"
+         "Return information about a package and the specified version"
     :> Capture "version" Version
     :> Get '[JSON] (PackageDTO 0)
 
 type GetPackageDependencies =
   Summary "Get dependencies of a package"
     :> Description
-        "Return dependencies of a package"
+         "Return dependencies of a package"
     :> Capture "version" Version
     :> "dependencies"
     :> QueryFlag "transitive"
@@ -36,7 +36,7 @@ type GetPackageDependencies =
 type GetPackagesByPrefix =
   Summary "Get a list of packages"
     :> Description
-        "Return a list of packages, given a prefix"
+         "Return a list of packages, given a prefix"
     :> Get '[JSON] (Vector PackageName)
 
 data API' mode = API'

--- a/src/web/FloraWeb/API/Server/Packages.hs
+++ b/src/web/FloraWeb/API/Server/Packages.hs
@@ -2,9 +2,9 @@ module FloraWeb.API.Server.Packages where
 
 import Data.Function
 import Data.Maybe (fromMaybe)
-import Data.Vector (Vector)
 import Data.Text (Text)
 import Data.Text.Display
+import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Distribution.Version (Version)
 import Effectful (Eff, IOE, liftIO, (:>))

--- a/src/web/FloraWeb/API/Server/Packages.hs
+++ b/src/web/FloraWeb/API/Server/Packages.hs
@@ -9,7 +9,9 @@ import Data.Vector qualified as Vector
 import Distribution.Version (Version)
 import Effectful (Eff, IOE, liftIO, (:>))
 import Effectful.Error.Static (Error)
+import Effectful.Log (Log)
 import Effectful.PostgreSQL.Transact.Effect (DB)
+import Effectful.Time (Time)
 import Effectful.Trace
 import Servant hiding ((:>))
 
@@ -21,6 +23,7 @@ import Flora.Model.Package.Types
 import Flora.Model.Release.Guard (guardThatReleaseExists)
 import Flora.Model.Release.Query qualified as Query
 import Flora.Model.Release.Types
+import Flora.Search (searchPackageByName)
 import FloraWeb.API.Errors
 import FloraWeb.API.Routes.Packages qualified as Packages
 import FloraWeb.API.Routes.Packages.Types
@@ -94,16 +97,19 @@ getPackageHandler namespace packageName = do
 
 getPackagesByPrefixHandler
   :: ( DB :> es
-     , Error ServerError :> es
-     , IOE :> es
-     , Trace :> es
+     , Log :> es
+     , Time :> es
      )
   => Text
+  -> Maybe Word
+  -> Maybe Word
   -> (Eff es) (Vector PackageName)
-getPackagesByPrefixHandler packageName = do
-  (packages :: Vector Package) <- Query.getPackagesByPrefix packageName
+getPackagesByPrefixHandler packageName maybeOffset maybeLimit = do
+  let offset = fromMaybe 0 maybeOffset
+  let limit = fromMaybe 10 maybeLimit
+  (_, packagesInfo) <- searchPackageByName (offset, limit) packageName
   pure
-    (Vector.map (\p -> p.name) packages)
+    (Vector.map (\p -> p.name) packagesInfo)
 
 getVersionedPackageHandler
   :: ( DB :> es


### PR DESCRIPTION
## Proposed changes
Implements #835.
A new route under `/api/experimental/packages/search/:packageNamePrefix` is added. It returns a vector of names of packages matching the prefix.

An example output:
```sh
$ curl http://localhost:8083/api/experimental/packages/search/text
["text-display","text-conversions","text-rope","text-manipulate","text-short","text","text-iso8601","text-zipper","text-icu"]⏎
```

## Contributor checklist

- [x] My PR is related to \<insert ticket number>
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
