### PR TITLE
docker: Load local environment variables by default

### DIFF
--- a/scripts/.zshrc
+++ b/scripts/.zshrc
@@ -8,6 +8,7 @@ ZSH_THEME="robbyrussell"
 plugins=(git)
 
 source $ZSH/oh-my-zsh.sh
+[ -f /flora-server/environment.local.sh ] && source /flora-server/environment.local.sh || source /flora-server/environment.sh
 source /flora-server/environment.docker.sh
 export PATH=${PATH}:~/.cabal/bin
 


### PR DESCRIPTION
## Proposed changes

Load variables from either `environment.local.sh` or `environment.sh` by default inside docker's shell

### Quickly get the change on existing installation

1. Enter your docker shell (`make docker-enter`)
2. Remove your existing zshrc: `rm ~/.zshrc`
3. Copy the new: `cp ./scripts/.zshrc ~/`

## Contributor checklist

- [ ] My PR is related to \<insert ticket number>
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
