### PR TITLE
Mobile header refactoring

### DIFF
--- a/assets/css/1-core/1-reset.css
+++ b/assets/css/1-core/1-reset.css
@@ -353,3 +353,12 @@ Ensure the default browser behavior of the `hidden` attribute.
 [hidden] {
 	display: none;
 }
+
+/*
+Hide polyfilled popovers
+*/
+@supports not selector(:popover-open) {
+  [popover]:not(.\:popover-open) {
+    display: none;
+  }
+}

--- a/assets/css/1-core/3-variables.css
+++ b/assets/css/1-core/3-variables.css
@@ -121,7 +121,7 @@
 		--link-decoration-color: var(--purple-70);
 		--link-hover-color: var(--blue-15);
 		--navbar-background-color: var(--blue-15);
-		--navbar-border-color: transparent;
+		--navbar-border-color: var(--blue-30);
 		--navbar-search-color: var(--gray-90);
 		--navbar-search-background-color: var(--blue-20);
 		--navbar-search-border-color: var(--blue-20);
@@ -170,7 +170,7 @@ html[data-theme="dark"] {
 	--link-decoration-color: var(--purple-70);
 	--link-hover-color: var(--blue-15);
 	--navbar-background-color: var(--blue-15);
-	--navbar-border-color: transparent;
+	--navbar-border-color: var(--blue-30);
 	--navbar-search-color: var(--gray-90);
 	--navbar-search-background-color: var(--blue-20);
 	--navbar-search-border-color: var(--blue-20);

--- a/assets/css/2-components/1-navbar.css
+++ b/assets/css/2-components/1-navbar.css
@@ -20,7 +20,7 @@
 		height: 4rem;
 		display: flex;
 
-		.navbar-dropdown {
+		.navbar-dropdown__button {
 			display: none;
 		}
 
@@ -28,13 +28,6 @@
 			display: flex;
 			align-items: center;
 			height: 4rem;
-
-			form {
-				max-width: 24rem;
-				width: 100%;
-				display: inline-flex;
-				margin-left: 1.25rem;
-			}
 		}
 
 		.brand {
@@ -79,6 +72,15 @@
 	}
 
 	.navbar-search {
+		max-width: 24rem;
+		width: 100%;
+		display: inline-flex;
+		align-items: center;
+		margin-left: 1.25rem;
+		padding-block: var(--space-2);
+	}
+
+	.navbar-searchInput {
 		background-color: var(--navbar-search-background-color);
 		border-radius: var(--space-md) 0 0 var(--space-md);
 		border: none;
@@ -105,7 +107,6 @@
 		color: currentcolor !important;
 	}
 
-
 	#navbar-search-package-name {
 		padding-left: 20px;
 	}
@@ -122,34 +123,83 @@
 			display: flex;
 			padding-left: 1rem;
 			padding-right: 1rem;
-
-			.navbar-left {
-				display: none;
-			}
+			height: auto;
 
 			.navbar-right {
 				display: none;
 			}
 
+			.navbar-left {
+				display: grid;
+				grid-template-columns: 1fr auto;
+				align-items: center;
+				gap: var(--space-3);
+				padding-block: var(--space-3);
+				flex-grow: 1;
+				height: auto;
+			}
+
+			.navbar-left .brand {
+				justify-self: flex-start;
+			}
+
+			.navbar-search {
+				grid-column: 1 / 3;
+				grid-row: 2 / 3;
+				max-width: initial;
+				margin-left: 0;
+				padding-bottom: 0;
+			}
+
+			.navbar-searchInput {
+				max-width: unset;
+				flex-grow: 1;
+			}
+
+			.navbar-searchBtn {
+				margin-right: 0;
+			}
+
 			.navbar-dropdown {
 				align-items: center;
 				display: flex;
+			}
 
-				.navbar-dropdown__button {
-					color: rgb(255 255 255);
-					font-weight: 700;
-					text-decoration: none;
-				}
+			.navbar-dropdown__button {
+				display: inline-flex;
+				color: rgb(255 255 255);
+				font-weight: 700;
+				text-decoration: none;
+				gap: .5ch;
+				vertical-align: middle;
+			}
 
-				.navbar-dropdown__menu {
-					background-color: var(--navbar-background-color);
-					display: flex;
-					flex-direction: column;
-					width: 100%;
-					left: 0;
-					top: 100%;
-					position: absolute;
-				}
+			.navbar-dropdown__button::before {
+				content: "☰" / "";
+				font-size: 1.9cap;
+				line-height: .9;
+			}
+
+			.navbar-dropdown__menu {
+				position: fixed;
+				box-sizing: content-box;
+				background-color: var(--navbar-background-color);
+				display: flex;
+				flex-direction: column;
+				left: 1rem;
+				right: 1rem;
+				top: 4rem;
+				border: .0625rem solid var(--navbar-border-color);
+				border-radius: var(--space-md);
+				margin: 0;
+				margin-left: auto;
+			}
+
+			.navbar-dropdown__menu:is(
+				:not(:popover-open),
+				:not(.\:popover-open)
+			) {
+				display: none;
 			}
 		}
 	}

--- a/assets/esbuild.config.js
+++ b/assets/esbuild.config.js
@@ -74,6 +74,8 @@ const config = {
   sourcemap: sourcemap,
   minify: minify,
   target: "es2018",
+  format: 'esm',
+  splitting: true,
   entryNames: entryNames,
   plugins: pluginsList(),
   metafile: true,

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,8 @@
 import './htmx.js';
 import 'htmx-ext-sse';
 
+import './polyfills.js';
+
 import Alpine from "alpinejs";
 window.Alpine = Alpine;
 Alpine.start();

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,0 +1,10 @@
+// Popover API
+// delete HTMLElement.prototype.popover
+if (!(
+	typeof HTMLElement !== 'undefined' &&
+	typeof HTMLElement.prototype === 'object' &&
+	'popover' in HTMLElement.prototype
+)) {
+	console.log('Popover API polyfill needed');
+	import('@oddbird/popover-polyfill');
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,6 +20,7 @@
     "stylelint-config-standard": "^36.0.1"
   },
   "dependencies": {
+    "@oddbird/popover-polyfill": "^0.6.1",
     "alpinejs": "^3.14.9",
     "htmx-ext-sse": "^2.2.2",
     "htmx.org": "^2.0.2"

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -233,6 +233,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@oddbird/popover-polyfill@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@oddbird/popover-polyfill/-/popover-polyfill-0.6.1.tgz#dc2d49dd79cc74420eece5b97ccef6ba3f9d42a9"
+  integrity sha512-Papau51NPG+NajXvoEHCNT1CBJv4WIyvIGfH5gpJPLL8MZJt/4giC0jJ/mNZRtJmdzRuXWpUFB6QxkJa1RvMAQ==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"

--- a/src/web/FloraWeb/Components/Navbar.hs
+++ b/src/web/FloraWeb/Components/Navbar.hs
@@ -46,9 +46,9 @@ navbar = do
     ]
     $ do
       div_ [class_ "navbar-content"] $ do
-        navbarDropdown aboutNav packagesNav
         div_ [class_ "navbar-left"] $ do
           brand
+          navbarDropdown aboutNav packagesNav
           navbarSearch
         div_ [class_ "navbar-right"] $ do
           navBarLink "navbar-menu-button" "/" "Search on Flora" False
@@ -65,42 +65,22 @@ brand = do
 
 navbarDropdown :: Bool -> Bool -> FloraHTML
 navbarDropdown aboutNav packagesNav = do
-  let xData =
-        [str|
-    {
-      open: false,
-      toggle() {
-        this.open = this.open ? this.close() : true
-      },
-      close() {
-        this.open = false;
-      }
-    }
-  |]
-
   div_
     [ class_ "navbar-dropdown"
-    , xData_ xData
-    , xOn_ "keydown.escape.prevent.stop" "close()"
-    , xId_ "['dropdown-button']"
     ]
     $ do
       button_
         [ class_ "navbar-dropdown__button"
         , type_ "button"
-        , xOn_ "click" "toggle()"
-        , ariaExpanded_ "open"
-        , ariaControls_ "$id('dropdown-button')"
+        , popovertarget_ "navbar_dropdown_menu"
         ]
-        $ text "☰ Flora"
+        $ text "Menu"
       div_
         [ class_ "navbar-dropdown__menu"
-        , xShow_ "open"
-        , xOn_ "click.outside" "close()"
-        , id'_ "$id('dropdown-button')"
+        , id_ "navbar_dropdown_menu"
+        , popover_ ""
         ]
         $ do
-          navBarLink "navbar-menu-button" "/" "Search on Flora" False
           navBarLink' "/about" "About" aboutNav
           navBarLink' "/categories" "Categories" packagesNav
           navBarLink' "/packages" "Packages" packagesNav
@@ -141,23 +121,22 @@ navbarSearch = do
             case mContent of
               Nothing -> []
               Just content -> [value_ content]
-      form_ [action_ "/search", method_ "GET"] $ do
-        div_ [class_ "flex items-center py-2"] $ do
-          label_ [for_ "search", class_ "sr-only"] "Search a package"
-          input_ $
-            [ class_ "navbar-search"
-            , id_ "search"
-            , type_ "search"
-            , name_ "q"
-            , placeholder_ "Search a package"
-            ]
-              ++ contentValue
-          button_
-            [ class_ "navbar-searchBtn"
-            , type_ "submit"
-            , label_ "Search"
-            ]
-            Icons.lookingGlass
+      form_ [class_ "navbar-search", action_ "/search", method_ "GET"] $ do
+        label_ [for_ "search", class_ "sr-only"] "Search a package"
+        input_ $
+          [ class_ "navbar-searchInput"
+          , id_ "search"
+          , type_ "search"
+          , name_ "q"
+          , placeholder_ "Search a package"
+          ]
+            ++ contentValue
+        button_
+          [ class_ "navbar-searchBtn"
+          , type_ "submit"
+          , label_ "Search"
+          ]
+          Icons.lookingGlass
     else pure mempty
 
 adminLink :: Bool -> Maybe User -> FloraHTML
@@ -188,8 +167,6 @@ themeToggle = do
     , ariaLabel_ "Switch to dark theme"
     ]
     moonIcon
-
-  input_ [type_ "checkbox", name_ "", id_ "darkmode-toggle", class_ "hidden"]
 
 getUsernameOrLogin :: Maybe User -> FloraHTML
 getUsernameOrLogin Nothing = navBarLink' "/sessions/new" "Login" False


### PR DESCRIPTION
## Proposed changes

- Use native popover API for navigation menu (not requiring JS + better out-of-the-box accessibility)
- Popover polyfill for non-compatible browsers
- ESM output + code splitting configured on ESbuild to be able to conditionally load polyfills
- Header's search directly visible at the headers bottom 


https://github.com/user-attachments/assets/7e1c844b-1bc2-474d-8372-8281a7578f38

