### PR TITLE
move -Werror=unused-imports into run-tests.sh

### DIFF
--- a/flora.cabal
+++ b/flora.cabal
@@ -54,7 +54,6 @@ common common-ghc-options
     -Wno-unused-do-bind
     -fshow-hole-constraints
     -Wno-unticked-promoted-constructors
-    -Werror=unused-imports
     -fdicts-strict
     -fmax-worker-args=16
     -fspec-constr-recursive=16

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,7 +6,7 @@ set -eao pipefail
 
 if [ -z "$1" ] ;
 then
-  cabal test
+  cabal test --ghc-options="-Werror=unused-imports"
 else
   ghcid --command='cabal v2-repl flora-test' --test 'Main.main'
 fi


### PR DESCRIPTION
Now the normal build doesn't fail when you have an unused imports :) It would only fail when you run the testsuite via the Makefile or the test script.

## Proposed changes

## Contributor checklist

- [ ] My PR is related to \<insert ticket number>
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
