### PR TITLE
Remove nested withReadOnlyPool calls

### DIFF
--- a/src/web/FloraWeb/API/Server/Packages.hs
+++ b/src/web/FloraWeb/API/Server/Packages.hs
@@ -127,10 +127,9 @@ getPackagesByPrefixHandler maybePackageName maybeOffset maybeLimit =
   case maybePackageName of
     Nothing -> pure Vector.empty
     Just packageName -> do
-      FloraEnv{pool} <- Reader.ask
       let offset = fromMaybe 0 maybeOffset
       let limit = fromMaybe 10 maybeLimit
-      (_, packagesInfo) <- withReadOnlyPool pool $ searchPackageByName (offset, limit) packageName
+      (_, packagesInfo) <- searchPackageByName (offset, limit) packageName
       pure
         (Vector.map (\p -> p.name) packagesInfo)
 

--- a/src/web/FloraWeb/Pages/Server/Packages.hs
+++ b/src/web/FloraWeb/Pages/Server/Packages.hs
@@ -93,10 +93,9 @@ listPackagesHandler
   -> FloraM es (Html ())
 listPackagesHandler (Headers session _) pageParam = do
   Tracing.rootSpan alwaysSampled "list-all-packages" $ do
-    FloraEnv{pool} <- Reader.ask
     let pageNumber = pageParam ?: PositiveUnsafe 1
     templateEnv' <- templateFromSession session defaultTemplateEnv
-    (count', results) <- withReadOnlyPool pool $ Search.listAllPackages (fromPage pageNumber)
+    (count', results) <- Search.listAllPackages (fromPage pageNumber)
     let templateEnv =
           templateEnv'
             { title = "Packages — Flora.pm"
@@ -122,7 +121,7 @@ showNamespaceHandler (Headers session _) packageNamespace pageParam =
     FloraEnv{pool} <- Reader.ask
     let pageNumber = pageParam ?: PositiveUnsafe 1
     templateDefaults <- templateFromSession session defaultTemplateEnv
-    (count', results) <- withReadOnlyPool pool $ Search.listAllPackagesInNamespace (fromPage pageNumber) packageNamespace
+    (count', results) <- Search.listAllPackagesInNamespace (fromPage pageNumber) packageNamespace
     mPackageIndex <- withReadOnlyPool pool $ Query.getPackageIndexByName (extractNamespaceText packageNamespace)
     case mPackageIndex of
       Nothing -> renderError templateDefaults notFound404


### PR DESCRIPTION
The outer calls here are not used, and in fact, nested acquisition of resources from a pool can cause deadlocks (scary!)

## Proposed changes

## Contributor checklist

- [ ] My PR is related to \<insert ticket number>
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
