### PR TITLE
Display green badge on latest non deprecated release

### DIFF
--- a/src/core/Flora/Model/Release/Query.hs
+++ b/src/core/Flora/Model/Release/Query.hs
@@ -20,6 +20,7 @@ module Flora.Model.Release.Query
   , getVersionFromManyReleaseIds
   , getReleasePackageIndex
   , getLatestReleases
+  , getLatestPackageReleaseVersion
   )
 where
 
@@ -279,4 +280,20 @@ getLatestReleases =
       FROM latest_versions as l0
       ORDER BY l0.uploaded_at DESC
       LIMIT 6
+      |]
+
+getLatestPackageReleaseVersion
+  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  => PackageId
+  -> FloraM es (Maybe Version)
+getLatestPackageReleaseVersion packageId = do
+  result :: (Maybe (Only Version)) <- labeled @ReadOnly @WithConnection $ queryOne sqlQuery (Only packageId)
+  pure $ fromOnly <$> result
+  where
+    sqlQuery =
+      [sql|
+      SELECT l0.version
+      FROM latest_versions as l0
+      WHERE l0.package_id = ?
+      LIMIT 1
       |]

--- a/src/web/FloraWeb/Pages/Server/Packages.hs
+++ b/src/web/FloraWeb/Pages/Server/Packages.hs
@@ -502,7 +502,6 @@ listVersionsHandler (Headers session _) packageNamespace packageName = do
           numberOfDependencies
           numberOfDependents
           package
-          latestRelease.synopsis
           releases
 
 constructTarballPath :: PackageName -> Version -> Text
@@ -574,6 +573,5 @@ showPackageSecurityHandler (Headers session _) packageNamespace packageName =
             numberOfDependencies
             numberOfDependents
             package
-            latestRelease.synopsis
             numberOfReleases
             (Vector.reverse $ Vector.modify (MVector.sortBy (\v1 v2 -> compare v1.hsecId v2.hsecId)) advisoryPreviews)

--- a/src/web/FloraWeb/Pages/Server/Packages.hs
+++ b/src/web/FloraWeb/Pages/Server/Packages.hs
@@ -239,7 +239,11 @@ showPackageVersion (Headers session _) packageNamespace packageName mversion =
         ]
 
     let packageIndexURL = packageIndex.url
-
+    isLatestViableRelease <- do
+      result <- withReadOnlyPool pool $ Query.getLatestPackageReleaseVersion package.packageId
+      case result of
+        Nothing -> pure False
+        Just v -> pure $ v == release.version
     Trace.withSpan "render showPackage" $
       render templateEnv $
         Packages.showPackage
@@ -254,6 +258,7 @@ showPackageVersion (Headers session _) packageNamespace packageName mversion =
           groups
           activeMaintainers
           mUploader
+          isLatestViableRelease
 
 showDependentsHandler
   :: ( Error ServerError :> es
@@ -324,6 +329,11 @@ showVersionDependentsHandler (Headers session _) packageNamespace packageName ve
     numberOfDependencies <- withReadOnlyPool pool $ Query.getNumberOfPackageRequirements release.releaseId
     numberOfReleases <- withReadOnlyPool pool $ Query.getNumberOfReleases package.packageId
     now <- Time.currentTime
+    isLatestViableRelease <- do
+      result <- withReadOnlyPool pool $ Query.getLatestPackageReleaseVersion package.packageId
+      case result of
+        Nothing -> pure False
+        Just v -> pure $ v == release.version
 
     Trace.withSpan "render showDependents" $
       render templateEnv $
@@ -336,6 +346,7 @@ showVersionDependentsHandler (Headers session _) packageNamespace packageName ve
           package
           results
           pageNumber
+          isLatestViableRelease
 
 showDependenciesHandler
   :: ( Error ServerError :> es
@@ -391,6 +402,11 @@ showVersionDependenciesHandler (Headers session _) packageNamespace packageName 
           Query.getAllRequirements release.releaseId
 
     now <- Time.currentTime
+    isLatestViableRelease <- do
+      result <- withReadOnlyPool pool $ Query.getLatestPackageReleaseVersion package.packageId
+      case result of
+        Nothing -> pure False
+        Just v -> pure $ v == release.version
     Trace.withSpan "render showDependencies" $
       render templateEnv $
         Package.showDependencies
@@ -401,6 +417,7 @@ showVersionDependenciesHandler (Headers session _) packageNamespace packageName 
           numberOfDependents
           package
           releaseDependencies
+          isLatestViableRelease
 
 showChangelogHandler
   :: ( Error ServerError :> es
@@ -452,6 +469,11 @@ showVersionChangelogHandler (Headers session _) packageNamespace packageName ver
             { title = display packageNamespace <> "/" <> display packageName
             , description = "Changelog of " <> display packageNamespace <> "/" <> display packageName
             }
+    isLatestViableRelease <- do
+      result <- withReadOnlyPool pool $ Query.getLatestPackageReleaseVersion package.packageId
+      case result of
+        Nothing -> pure False
+        Just v -> pure $ v == release.version
 
     render templateEnv $
       Package.showChangelog
@@ -461,6 +483,7 @@ showVersionChangelogHandler (Headers session _) packageNamespace packageName ver
         numberOfDependents
         package
         release.changelog
+        isLatestViableRelease
 
 listVersionsHandler
   :: ( Error ServerError :> es
@@ -494,7 +517,11 @@ listVersionsHandler (Headers session _) packageNamespace packageName = do
             Query.getNumberOfPackageDependents packageNamespace packageName Nothing
       numberOfDependencies <- withReadOnlyPool pool $ Query.getNumberOfPackageRequirements latestRelease.releaseId
       releases <- withReadOnlyPool pool $ Query.getAllReleases package.packageId
-
+      isLatestViableRelease <- do
+        result <- withReadOnlyPool pool $ Query.getLatestPackageReleaseVersion package.packageId
+        case result of
+          Nothing -> pure False
+          Just v -> pure $ v == latestRelease.version
       render templateEnv $
         Package.listVersions
           latestRelease
@@ -503,6 +530,7 @@ listVersionsHandler (Headers session _) packageNamespace packageName = do
           numberOfDependents
           package
           releases
+          isLatestViableRelease
 
 constructTarballPath :: PackageName -> Version -> Text
 constructTarballPath pname v = display pname <> "-" <> display v <> ".tar.gz"
@@ -575,3 +603,4 @@ showPackageSecurityHandler (Headers session _) packageNamespace packageName =
             package
             numberOfReleases
             (Vector.reverse $ Vector.modify (MVector.sortBy (\v1 v2 -> compare v1.hsecId v2.hsecId)) advisoryPreviews)
+            True

--- a/src/web/FloraWeb/Pages/Templates/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Packages.hs
@@ -107,7 +107,6 @@ showDependents now numberOfReleases latestRelease numberOfDependencies numberOfD
     numberOfDependencies
     numberOfDependents
     package
-    latestRelease.synopsis
     mempty
     "dependents"
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
@@ -151,7 +150,6 @@ showDependencies now numberOfReleases latestRelease numberOfDependencies numberO
     numberOfDependencies
     numberOfDependents
     package
-    latestRelease.synopsis
     mempty
     "dependencies"
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
@@ -165,17 +163,15 @@ listVersions
   -> Word
   -> Word
   -> Package
-  -> Text
   -> Vector Release
   -> FloraHTML
-listVersions latestRelease now numberOfDependencies numberOfDependents package synopsis releases = do
+listVersions latestRelease now numberOfDependencies numberOfDependents package releases = do
   presentationHeader
     (fromIntegral $ Vector.length releases)
     latestRelease
     numberOfDependencies
     numberOfDependents
     package
-    synopsis
     mempty
     "versions"
 
@@ -291,7 +287,6 @@ showChangelog numberOfReleases latestRelease numberOfDependencies numberOfDepend
     numberOfDependencies
     numberOfDependents
     package
-    latestRelease.synopsis
     mempty
     "changelog"
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
@@ -517,18 +512,16 @@ showPackageSecurityPage
   -> Word
   -> Word
   -> Package
-  -> Text
   -> Word
   -> Vector PackageAdvisoryPreview
   -> FloraHTML
-showPackageSecurityPage latestRelease numberOfDependencies numberOfDependents package synopsis numberOfReleases advisoryPreviews = do
+showPackageSecurityPage latestRelease numberOfDependencies numberOfDependents package numberOfReleases advisoryPreviews = do
   presentationHeader
     numberOfReleases
     latestRelease
     numberOfDependencies
     numberOfDependents
     package
-    synopsis
     mempty
     "security"
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
@@ -610,12 +603,10 @@ presentationHeader
   -> Word
   -- ^ Number of dependents
   -> Package
-  -> Text
-  -- ^  Synopsis
   -> Vector PackageGroupName
   -> String
   -> FloraHTML
-presentationHeader numberOfReleases release numberOfDependencies numberOfDependents package@Package{namespace, name, deprecationInfo} synopsis groups sectionId =
+presentationHeader numberOfReleases release numberOfDependencies numberOfDependents package@Package{namespace, name, deprecationInfo} groups sectionId =
   header_ [class_ "pageHead"] $ do
     div_ [class_ "wrapper flow flow--large"] $ do
       div_ [class_ "aside gap--large"] $ do
@@ -625,7 +616,7 @@ presentationHeader numberOfReleases release numberOfDependencies numberOfDepende
               a_ [href_ (Links.namespacePage package.namespace (PositiveUnsafe 1))] (toHtml $ display namespace)
               toHtmlRaw ("&ThinSpace;/&ThinSpace;" :: Text)
             toHtml package.name
-          p_ [class_ "pageHead-subtitle text-break"] (toHtml synopsis)
+          p_ [class_ "pageHead-subtitle text-break"] (toHtml release.synopsis)
         div_ [class_ "flow flow--small self-center"] $ do
           div_ [class_ "cluster cluster--small items-end"] $ do
             -- TODO: [non-urgent] Display for latest non-deprecated release

--- a/src/web/FloraWeb/Pages/Templates/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Packages.hs
@@ -99,8 +99,9 @@ showDependents
   -> Package
   -> Vector DependencyInfo
   -> Positive Word
+  -> Bool
   -> FloraHTML
-showDependents now numberOfReleases latestRelease numberOfDependencies numberOfDependents package packagesInfo currentPage = do
+showDependents now numberOfReleases latestRelease numberOfDependencies numberOfDependents package packagesInfo currentPage latestViableRelease = do
   presentationHeader
     numberOfReleases
     latestRelease
@@ -109,6 +110,8 @@ showDependents now numberOfReleases latestRelease numberOfDependencies numberOfD
     package
     mempty
     "dependents"
+    False
+    latestViableRelease
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
     h2_ [class_ "title-2"] "Dependents"
     ul_ [class_ "flow", role_ "list"] $ do
@@ -142,8 +145,9 @@ showDependencies
   -> Word
   -> Package
   -> ComponentDependencies
+  -> Bool
   -> FloraHTML
-showDependencies now numberOfReleases latestRelease numberOfDependencies numberOfDependents package componentsInfo = do
+showDependencies now numberOfReleases latestRelease numberOfDependencies numberOfDependents package componentsInfo isLatestViableRelease = do
   presentationHeader
     numberOfReleases
     latestRelease
@@ -152,6 +156,8 @@ showDependencies now numberOfReleases latestRelease numberOfDependencies numberO
     package
     mempty
     "dependencies"
+    True
+    isLatestViableRelease
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
     h2_ [class_ "title-2"] "Dependencies"
     ul_ [class_ "flow", role_ "list"] $ do
@@ -164,8 +170,9 @@ listVersions
   -> Word
   -> Package
   -> Vector Release
+  -> Bool
   -> FloraHTML
-listVersions latestRelease now numberOfDependencies numberOfDependents package releases = do
+listVersions latestRelease now numberOfDependencies numberOfDependents package releases isLatestViableRelease = do
   presentationHeader
     (fromIntegral $ Vector.length releases)
     latestRelease
@@ -174,6 +181,8 @@ listVersions latestRelease now numberOfDependencies numberOfDependents package r
     package
     mempty
     "versions"
+    False
+    isLatestViableRelease
 
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
     h2_ [class_ "title-2"] "Version history"
@@ -279,8 +288,9 @@ showChangelog
   -> Word
   -> Package
   -> Maybe TextHtml
+  -> Bool
   -> FloraHTML
-showChangelog numberOfReleases latestRelease numberOfDependencies numberOfDependents package mChangelog = do
+showChangelog numberOfReleases latestRelease numberOfDependencies numberOfDependents package mChangelog latestViableRelease = do
   presentationHeader
     numberOfReleases
     latestRelease
@@ -289,6 +299,8 @@ showChangelog numberOfReleases latestRelease numberOfDependencies numberOfDepend
     package
     mempty
     "changelog"
+    True
+    latestViableRelease
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
     h2_ [class_ "title-2"] "Changelog"
     div_ [class_ "prose"] $ do
@@ -514,8 +526,9 @@ showPackageSecurityPage
   -> Package
   -> Word
   -> Vector PackageAdvisoryPreview
+  -> Bool
   -> FloraHTML
-showPackageSecurityPage latestRelease numberOfDependencies numberOfDependents package numberOfReleases advisoryPreviews = do
+showPackageSecurityPage latestRelease numberOfDependencies numberOfDependents package numberOfReleases advisoryPreviews isLatestViableRelease = do
   presentationHeader
     numberOfReleases
     latestRelease
@@ -524,6 +537,8 @@ showPackageSecurityPage latestRelease numberOfDependencies numberOfDependents pa
     package
     mempty
     "security"
+    False
+    isLatestViableRelease
   section_ [class_ "wrapper inset-large flow", id_ "content"] $ do
     h2_ [class_ "title-2"] "Security Advisories"
     packageAdvisoriesListing False advisoryPreviews
@@ -605,8 +620,10 @@ presentationHeader
   -> Package
   -> Vector PackageGroupName
   -> String
+  -> Bool
+  -> Bool
   -> FloraHTML
-presentationHeader numberOfReleases release numberOfDependencies numberOfDependents package@Package{namespace, name, deprecationInfo} groups sectionId =
+presentationHeader numberOfReleases release numberOfDependencies numberOfDependents package@Package{namespace, name, deprecationInfo} groups sectionId latestViableRelease showVersion =
   header_ [class_ "pageHead"] $ do
     div_ [class_ "wrapper flow flow--large"] $ do
       div_ [class_ "aside gap--large"] $ do
@@ -619,20 +636,25 @@ presentationHeader numberOfReleases release numberOfDependencies numberOfDepende
           p_ [class_ "pageHead-subtitle text-break"] (toHtml release.synopsis)
         div_ [class_ "flow flow--small self-center"] $ do
           div_ [class_ "cluster cluster--small items-end"] $ do
-            -- TODO: [non-urgent] Display for latest non-deprecated release
-            -- span_ [class_ "badge badge--big badge--green"] $ do
-            --   Icons.check
-            --   "Latest"
-            whenJust deprecationInfo $ \_ ->
-              span_ [class_ "badge badge--danger"] $ do
-                span_ [class_ "sr-only"] "Version "
-                Icons.trash
-                "Deprecated"
-            when (release.deprecated == Just True) $
-              span_ [class_ "badge badge--big badge--danger"] $ do
-                Icons.trash
-                "Deprecated"
-            span_ [class_ "title-2 text-right leading-thin"] $ toHtml release.version
+            when showVersion $ do
+              case release.deprecated of
+                Just True -> do
+                  span_ [class_ "badge badge--big badge--danger"] $ do
+                    Icons.trash
+                    "Deprecated release"
+                _ ->
+                  case deprecationInfo of
+                    Just _ ->
+                      span_ [class_ "badge badge--big badge--danger"] $ do
+                        span_ [class_ "sr-only"] "Version "
+                        Icons.trash
+                        "Deprecated package"
+                    _ -> do
+                      when latestViableRelease $
+                        span_ [class_ "badge badge--big badge--green"] $ do
+                          Icons.check
+                          "Latest"
+              span_ [class_ "title-2 text-right leading-thin"] $ toHtml release.version
       div_ [class_ "pageHead-tip"] $ do
         -- TODO: [non-urgent] Split tabs in a separate function
         nav_ [class_ "tabs", id_ "subsections", ariaLabel_ "Package sections"] $ do

--- a/src/web/FloraWeb/Pages/Templates/Screens/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Packages.hs
@@ -40,6 +40,7 @@ showPackage
   -> Vector PackageGroupName
   -> Maybe (Vector Text)
   -> Maybe PackageUploader
+  -> Bool
   -> FloraHTML
 showPackage
   release
@@ -52,7 +53,8 @@ showPackage
   categories
   groups
   activeMaintainers
-  mUploader = do
+  mUploader
+  isLatestViableRelease = do
     presentationHeader
       numberOfReleases
       release
@@ -61,6 +63,8 @@ showPackage
       package
       groups
       "about"
+      isLatestViableRelease
+      True
     div_ [class_ "wrapper inset-large"] $ do
       packageBody
         package

--- a/src/web/FloraWeb/Pages/Templates/Screens/Packages.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Packages.hs
@@ -42,7 +42,7 @@ showPackage
   -> Maybe PackageUploader
   -> FloraHTML
 showPackage
-  latestRelease
+  release
   packageReleases
   numberOfReleases
   package
@@ -55,18 +55,17 @@ showPackage
   mUploader = do
     presentationHeader
       numberOfReleases
-      latestRelease
+      release
       numberOfDependencies
       numberOfDependents
       package
-      latestRelease.synopsis
       groups
       "about"
     div_ [class_ "wrapper inset-large"] $ do
       packageBody
         package
         packageIndexURL
-        latestRelease
+        release
         packageReleases
         categories
         (fmap Vector.length activeMaintainers)


### PR DESCRIPTION
This PR displays a green badge in the presentation header when we are browsing the latest non-deprecated release of a package

<img width="2560" height="373" alt="Screenshot 2026-06-05 at 20-54-14 @hackage › accelerate — Flora pm" src="https://github.com/user-attachments/assets/6af099bb-0501-428c-a309-4297d9c9696d" />

---

This PR also rationalises the way the deprecation badges are shown and under what conditions.

<img width="2560" height="373" alt="Screenshot 2026-06-05 at 20-42-03 @hackage_ansi-wl-pprint" src="https://github.com/user-attachments/assets/89298aa0-8bd5-487c-bb2a-eb4e6891f78f" />
<img width="2560" height="373" alt="Screenshot 2026-06-05 at 20-42-00 @hackage_binary" src="https://github.com/user-attachments/assets/bbb54344-1ed5-4f91-945e-6c10a7de1118" />
<img width="2560" height="373" alt="Screenshot 2026-06-05 at 20-41-50 @hackage › binary — Flora pm" src="https://github.com/user-attachments/assets/c23e9e9c-cc8d-4da1-b2a1-9200ccfb83fc" />
