### PR TITLE
Rework the database layer

### DIFF
--- a/app/cli/Main.hs
+++ b/app/cli/Main.hs
@@ -330,7 +330,7 @@ importIndex
   -> FloraM es ()
 importIndex indexArchivebasePath repository = do
   FloraEnv{pool} <- Reader.ask
-  mPackageIndex <- withReadOnlyPool pool $ withReadWritePool pool $ Query.getPackageIndexByName repository
+  mPackageIndex <- withReadOnlyPool pool $ Query.getPackageIndexByName repository
   case mPackageIndex of
     Nothing -> error $ Text.unpack $ "Package index " <> repository <> " not found in the database!"
     Just packageIndex -> do

--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -20,9 +20,7 @@ import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Effectful
 import Effectful.Fail (runFailIO)
 import Effectful.FileSystem
-import Effectful.Labeled
 import Effectful.Log
-import Effectful.PostgreSQL
 import Effectful.Reader.Static qualified as Reader
 import Log qualified
 import NoThunks.Class
@@ -77,7 +75,7 @@ checkFloraEnvForThunks env = do
         , "thunk_info" .= info.thunkInfo
         ]
 
-checkExpectedTables :: (IOE :> es, IOE :> es, Labeled ReadOnly WithConnection :> es, Log :> es) => FloraM es ()
+checkExpectedTables :: (IOE :> es, Log :> es, ReadDB :> es) => FloraM es ()
 checkExpectedTables = do
   -- Update the list in alphabetical order when adding or removing a table!
   let expectedTables =
@@ -114,10 +112,9 @@ checkExpectedTables = do
           , "users"
           ]
   actualTables <-
-    labeled @ReadOnly @WithConnection $
-      Set.fromAscList . List.map fromOnly
-        <$> query_
-          [sql|
+    Set.fromAscList . List.map fromOnly
+      <$> query_
+        [sql|
       SELECT table_name
       FROM information_schema.tables
       WHERE table_name <> 'schema_migrations'
@@ -155,13 +152,12 @@ checkExpectedTables = do
     forM_ messages Log.logAttention_
     liftIO exitFailure
 
-checkRepositoriesAreConfigured :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Log :> es) => Eff es ()
+checkRepositoriesAreConfigured :: (IOE :> es, Log :> es, ReadDB :> es) => Eff es ()
 checkRepositoriesAreConfigured = do
   let expectedRepositories = Set.fromList ["hackage", "cardano", "horizon", "mlabs"]
   (result :: (List (Only Text))) <-
-    labeled @ReadOnly @WithConnection $
-      query_
-        (_selectWithFields @PackageIndex [[field| repository |]])
+    query_
+      (_selectWithFields @PackageIndex [[field| repository |]])
   let actualRepositories = Set.fromList $ List.map fromOnly result
   let missingExpectedIndexes = Set.difference expectedRepositories actualRepositories
   let unexpectedIndexes = Set.difference actualRepositories expectedRepositories

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ test-show-details: direct
 jobs: $ncpus
 
 package *
-  ghc-options: +RTS -I0 -RTS -finfo-table-map -fdistinct-constructor-tables
+  ghc-options: +RTS -I0 -RTS -finfo-table-map -fdistinct-constructor-tables -fwrite-ide-info
 
 allow-newer: chronos:hashable
            , feed:*

--- a/environment.test.local.kdl
+++ b/environment.test.local.kdl
@@ -1,0 +1,35 @@
+flora {
+  domain localhost
+  httpPort 8084
+  jobsHttpPort 8086
+  environment test
+  db {
+    host "flora-database"
+    port 5432
+    user "postgres"
+    password "postgres"
+    dbname "flora_test"
+    sslmode "allow"
+  }
+
+  pool {
+    timeout 10
+    connections 15
+  }
+
+
+  mltp {
+    sentryDSN ""
+    prometheusEnabled #false
+    loggingDestination stdout
+    zipkinEnabled #false
+    zipkinHost localhost
+    zipkinPort 8800
+    eventlogSocket "/tmp/flora-eventlog.sock"
+  }
+
+  features {
+    tarballsEnabled #false
+    blobStoreFilePath #null
+  }
+}

--- a/src/advisories/Advisories/Model/Advisory/Query.hs
+++ b/src/advisories/Advisories/Model/Advisory/Query.hs
@@ -9,8 +9,6 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Entity.Types
 import Database.PostgreSQL.Simple (Only (Only))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Security.Advisories.Core.HsecId
 
 import Advisories.Model.Advisory.Types
@@ -18,17 +16,16 @@ import Advisories.Model.Affected.Types
 import Flora.Database
 import Flora.Model.Package.Types
 
-getAdvisoryById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => AdvisoryId -> Eff es (Maybe AdvisoryDAO)
-getAdvisoryById advisoryId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @AdvisoryDAO [primaryKey @AdvisoryDAO]) (Only advisoryId)
+getAdvisoryById :: (IOE :> es, ReadDB :> es) => AdvisoryId -> Eff es (Maybe AdvisoryDAO)
+getAdvisoryById advisoryId = queryOne (_selectWhere @AdvisoryDAO [primaryKey @AdvisoryDAO]) (Only advisoryId)
 
-getAdvisoryByHsecId :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => HsecId -> Eff es (Maybe AdvisoryDAO)
-getAdvisoryByHsecId hsecId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @AdvisoryDAO [[field| hsec_id |]]) (Only hsecId)
+getAdvisoryByHsecId :: (IOE :> es, ReadDB :> es) => HsecId -> Eff es (Maybe AdvisoryDAO)
+getAdvisoryByHsecId hsecId = queryOne (_selectWhere @AdvisoryDAO [[field| hsec_id |]]) (Only hsecId)
 
 getAdvisoriesByPackageId
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> Eff es (Vector AdvisoryDAO)
 getAdvisoriesByPackageId packageId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query (_joinSelectOneByField @AdvisoryDAO @AffectedPackageDAO [field| advisory_id |] [field| package_id |]) (Only packageId)
+  Vector.fromList
+    <$> query (_joinSelectOneByField @AdvisoryDAO @AffectedPackageDAO [field| advisory_id |] [field| package_id |]) (Only packageId)

--- a/src/advisories/Advisories/Model/Advisory/Update.hs
+++ b/src/advisories/Advisories/Model/Advisory/Update.hs
@@ -3,11 +3,9 @@ module Advisories.Model.Advisory.Update where
 import Control.Monad
 import Database.PostgreSQL.Entity
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Advisories.Model.Advisory.Types
 import Flora.Database
 
-insertAdvisory :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => AdvisoryDAO -> Eff es ()
-insertAdvisory = labeled @ReadWrite @WithConnection . void . execute (_insert @AdvisoryDAO)
+insertAdvisory :: (IOE :> es, WriteDB :> es) => AdvisoryDAO -> Eff es ()
+insertAdvisory = void . execute (_insert @AdvisoryDAO)

--- a/src/advisories/Advisories/Model/Affected/Query.hs
+++ b/src/advisories/Advisories/Model/Affected/Query.hs
@@ -11,8 +11,6 @@ import Database.PostgreSQL.Entity.Types (field)
 import Database.PostgreSQL.Simple (Only (..), Query)
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Security.Advisories.Core.HsecId
 
 import Advisories.HsecId.Orphans ()
@@ -22,33 +20,31 @@ import Flora.Database
 import Flora.Model.Package.Types
 
 getAffectedPackageById
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => AffectedPackageId
   -> Eff es (Maybe AffectedPackageDAO)
-getAffectedPackageById affectedPackageId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @AffectedPackageDAO [primaryKey @AffectedPackageDAO]) (Only affectedPackageId)
+getAffectedPackageById affectedPackageId = queryOne (_selectWhere @AffectedPackageDAO [primaryKey @AffectedPackageDAO]) (Only affectedPackageId)
 
 getAffectedPackagesByAdvisoryId
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => AdvisoryId
   -> Eff es (Vector AffectedPackageDAO)
 getAffectedPackagesByAdvisoryId advisoryId =
-  labeled @ReadOnly @WithConnection $ Vector.fromList <$> query (_selectWhere @AffectedPackageDAO [[field| advisory_id |]]) (Only advisoryId)
+  Vector.fromList <$> query (_selectWhere @AffectedPackageDAO [[field| advisory_id |]]) (Only advisoryId)
 
 getAffectedPackagesByHsecId
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => HsecId
   -> Eff es (Vector AffectedPackageDAO)
 getAffectedPackagesByHsecId hsecId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query (_joinSelectOneByField @AffectedPackageDAO @AdvisoryDAO [field| advisory_id |] [field| hsec_id |]) (Only hsecId)
+  Vector.fromList
+    <$> query (_joinSelectOneByField @AffectedPackageDAO @AdvisoryDAO [field| advisory_id |] [field| hsec_id |]) (Only hsecId)
 
-getAdvisoryPreviewsByPackageId :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> Eff es (Vector PackageAdvisoryPreview)
+getAdvisoryPreviewsByPackageId :: (IOE :> es, ReadDB :> es) => PackageId -> Eff es (Vector PackageAdvisoryPreview)
 getAdvisoryPreviewsByPackageId packageId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query
-        [sql|
+  Vector.fromList
+    <$> query
+      [sql|
 SELECT s0.hsec_id
      , p3.namespace
      , p3.name
@@ -67,15 +63,14 @@ FROM security_advisories AS s0
 WHERE a1.package_id = ?
 GROUP BY s0.hsec_id, p3.namespace, p3.name, s0.summary, fixed, s0.published, a1.cvss
   |]
-        (Only packageId)
+      (Only packageId)
 
-searchInAdvisories :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => (Word, Word) -> Text -> Eff es (Vector PackageAdvisoryPreview)
+searchInAdvisories :: (IOE :> es, ReadDB :> es) => (Word, Word) -> Text -> Eff es (Vector PackageAdvisoryPreview)
 searchInAdvisories (offset, limit) searchTerm =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query
-        searchAdvisoriesQuery
-        (searchTerm, searchTerm, offset, limit)
+  Vector.fromList
+    <$> query
+      searchAdvisoriesQuery
+      (searchTerm, searchTerm, offset, limit)
 
 searchAdvisoriesQuery :: Query
 searchAdvisoriesQuery =
@@ -114,16 +109,9 @@ SELECT r0.hsec_id
 FROM results as r0
   |]
 
-countAdvisorySearchResults :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es Word
+countAdvisorySearchResults :: (IOE :> es, ReadDB :> es) => Text -> Eff es Word
 countAdvisorySearchResults searchTerm =
-  labeled @ReadOnly @WithConnection $ do
-    (result :: Maybe (Only Int)) <-
-      queryOne
-        countAdvisorySearchResultsQuery
-        (searchTerm, searchTerm)
-    case result of
-      Just (Only n) -> pure $ fromIntegral n
-      Nothing -> pure 0
+  queryCount countAdvisorySearchResultsQuery (searchTerm, searchTerm)
 
 countAdvisorySearchResultsQuery :: Query
 countAdvisorySearchResultsQuery =

--- a/src/advisories/Advisories/Model/Affected/Update.hs
+++ b/src/advisories/Advisories/Model/Affected/Update.hs
@@ -3,20 +3,18 @@ module Advisories.Model.Affected.Update where
 import Control.Monad
 import Database.PostgreSQL.Entity
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Advisories.Model.Affected.Types
 import Flora.Database
 
 insertAffectedPackage
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => AffectedPackageDAO
   -> Eff es ()
-insertAffectedPackage = labeled @ReadWrite @WithConnection . void . execute (_insert @AffectedPackageDAO)
+insertAffectedPackage = void . execute (_insert @AffectedPackageDAO)
 
 insertAffectedVersionRange
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => AffectedVersionRangeDAO
   -> Eff es ()
-insertAffectedVersionRange = labeled @ReadWrite @WithConnection . void . execute (_insert @AffectedVersionRangeDAO)
+insertAffectedVersionRange = void . execute (_insert @AffectedVersionRangeDAO)

--- a/src/core/Flora/Database.hs
+++ b/src/core/Flora/Database.hs
@@ -1,35 +1,171 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
 module Flora.Database
-  ( AccessMode (..)
-  , withReadWritePool
-  , withReadOnlyPool
+  ( -- * Effects
+    ReadDB
+  , WriteDB
+
+    -- * Read operations
+  , query
+  , query_
   , queryOne
   , queryOne_
+  , queryCount
+  , queryCount_
+
+    -- * Write operations
+  , execute
+  , execute_
+  , executeMany
   , upsert
-  , withTransaction
+
+    -- * Interpreters
+  , withReadOnlyPool
+  , withReadWritePool
   ) where
 
-import Control.Monad
-import Data.Maybe
+import Control.Monad (void)
+import Data.Int (Int64)
+import Data.Maybe (listToMaybe)
 import Data.Pool (Pool)
 import Data.Pool.Introspection (Resource (..))
 import Data.Pool.Introspection qualified as Pool
 import Data.Text.Display
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
-import Database.PostgreSQL.Entity hiding (upsert)
-import Database.PostgreSQL.Simple
+import Database.PostgreSQL.Entity (Entity, primaryKey, _insert, _onConflictDoUpdate)
+import Database.PostgreSQL.Entity.Types (Field)
+import Database.PostgreSQL.Simple (Connection, FromRow, Only (..), Query, ToRow)
 import Database.PostgreSQL.Simple qualified as PG
+import Database.PostgreSQL.Simple.Transaction qualified as PGTransaction
 import Effectful
-import Effectful.Dispatch.Dynamic
-import Effectful.Labeled
+import Effectful.Dispatch.Dynamic (interpret, send)
 import Effectful.Log
-import Effectful.PostgreSQL qualified as DB
-import Effectful.PostgreSQL.Connection
 import Log qualified
 
-import Flora.Monad
+import Flora.Monad (FloraM)
+
+-- | The read capability: queries that return rows.
+data ReadDB :: Effect where
+  Query :: (FromRow r, ToRow q) => Query -> q -> ReadDB m [r]
+  Query_ :: FromRow r => Query -> ReadDB m [r]
+
+type instance DispatchOf ReadDB = Dynamic
+
+-- | The write capability: statements that change rows.
+data WriteDB :: Effect where
+  Execute :: ToRow q => Query -> q -> WriteDB m Int64
+  Execute_ :: Query -> WriteDB m Int64
+  ExecuteMany :: ToRow q => Query -> [q] -> WriteDB m Int64
+
+type instance DispatchOf WriteDB = Dynamic
+
+-- | Run a query with parameters.
+query :: (FromRow r, ReadDB :> es, ToRow q) => Query -> q -> Eff es [r]
+query q params = send (Query q params)
+
+-- | Run a parameterless query.
+query_ :: (FromRow r, ReadDB :> es) => Query -> Eff es [r]
+query_ q = send (Query_ q)
+
+-- | Run a query expecting at most one row.
+queryOne :: (FromRow r, ReadDB :> es, ToRow q) => Query -> q -> Eff es (Maybe r)
+queryOne q params = listToMaybe <$> query q params
+
+-- | Run a parameterless query expecting at most one row.
+queryOne_ :: (FromRow r, ReadDB :> es) => Query -> Eff es (Maybe r)
+queryOne_ q = listToMaybe <$> query_ q
+
+-- | Run a count query returning a single @Int@ column, yielding 0 when no row
+-- comes back.
+queryCount :: (Integral n, ReadDB :> es, ToRow q) => Query -> q -> Eff es n
+queryCount q params = maybe 0 (\(Only n) -> fromIntegral (n :: Int)) <$> queryOne q params
+
+-- | Parameterless 'queryCount'.
+queryCount_ :: (Integral n, ReadDB :> es) => Query -> Eff es n
+queryCount_ q = maybe 0 (\(Only n) -> fromIntegral (n :: Int)) <$> queryOne_ q
+
+-- | Run a statement with parameters, returning the number of affected rows.
+execute :: (ToRow q, WriteDB :> es) => Query -> q -> Eff es Int64
+execute q params = send (Execute q params)
+
+-- | Run a parameterless statement.
+execute_ :: WriteDB :> es => Query -> Eff es Int64
+execute_ q = send (Execute_ q)
+
+-- | Run a statement once per parameter row.
+executeMany :: (ToRow q, WriteDB :> es) => Query -> [q] -> Eff es Int64
+executeMany q params = send (ExecuteMany q params)
+
+-- | Insert an entity, replacing the given fields on primary-key conflict.
+upsert
+  :: forall e es values
+   . (Entity e, ToRow values, WriteDB :> es)
+  => values
+  -- ^ Entity to insert
+  -> Vector Field
+  -- ^ Fields to replace in case of conflict
+  -> Eff es ()
+upsert entity fieldsToReplace =
+  void $ execute (_insert @e <> _onConflictDoUpdate conflictTarget fieldsToReplace) entity
+  where
+    conflictTarget = Vector.singleton $ primaryKey @e
+
+-- | Discharge 'ReadDB' against a fixed connection.
+interpretReadDB :: IOE :> es => Connection -> Eff (ReadDB ': es) a -> Eff es a
+interpretReadDB conn = interpret $ \_ -> \case
+  Query q params -> liftIO (PG.query conn q params)
+  Query_ q -> liftIO (PG.query_ conn q)
+
+-- | Discharge 'WriteDB' against a fixed connection.
+interpretWriteDB :: IOE :> es => Connection -> Eff (WriteDB ': es) a -> Eff es a
+interpretWriteDB conn = interpret $ \_ -> \case
+  Execute q params -> liftIO (PG.execute conn q params)
+  Execute_ q -> liftIO (PG.execute_ conn q)
+  ExecuteMany q params -> liftIO (PG.executeMany conn q params)
+
+-- | Run a read-only action on a __single__ pooled connection wrapped in a
+-- single @READ ONLY@ transaction. Only 'ReadDB' is in scope, so writes are a
+-- compile error here.
+withReadOnlyPool
+  :: forall a es
+   . (IOE :> es, Log :> es)
+  => Pool Connection
+  -> Eff (ReadDB ': es) a
+  -> FloraM es a
+withReadOnlyPool pool action =
+  runTransaction ReadOnly pool $ \conn -> interpretReadDB conn action
+
+-- | Run a read-write action on a __single__ pooled connection wrapped in a
+-- single read-write transaction. Both 'WriteDB' and 'ReadDB' are discharged
+-- against that one connection, so reads issued by a write path share its
+-- transaction instead of drawing a second connection.
+withReadWritePool
+  :: forall a es
+   . (IOE :> es, Log :> es)
+  => Pool Connection
+  -> Eff (WriteDB ': ReadDB ': es) a
+  -> FloraM es a
+withReadWritePool pool action =
+  runTransaction ReadWrite pool $ \conn -> interpretReadDB conn (interpretWriteDB conn action)
+
+-- | Acquire one pooled connection in the transaction mode implied by the
+-- 'AccessMode' and run the supplied interpreter against it. The same
+-- 'AccessMode' drives both the connection log label and the Postgres
+-- transaction mode, so the two cannot drift.
+runTransaction
+  :: forall a es
+   . (IOE :> es, Log :> es)
+  => AccessMode
+  -> Pool Connection
+  -> (Connection -> Eff es a)
+  -> FloraM es a
+runTransaction mode pool run = do
+  loggerEnv <- getLoggerEnv
+  withRunInIO $ \io ->
+    unliftedWithResource mode loggerEnv pool $ \conn ->
+      PGTransaction.withTransactionMode (transactionMode mode) conn $
+        io (run conn)
 
 data AccessMode
   = ReadOnly
@@ -40,28 +176,11 @@ instance Display AccessMode where
   displayBuilder ReadOnly = "read_only"
   displayBuilder ReadWrite = "read_write"
 
-withPool
-  :: forall a es
-   . (IOE :> es, Log :> es)
-  => AccessMode
-  -> Pool PG.Connection
-  -> Eff (WithConnection ': es) a
-  -> FloraM es a
-withPool accessMode pool action = do
-  runWithConnectionPool accessMode pool $
-    DB.withTransaction action
-
-runWithConnectionPool
-  :: (HasCallStack, IOE :> es, Log :> es)
-  => AccessMode
-  -> Pool PG.Connection
-  -> Eff (WithConnection : es) a
-  -> Eff es a
-runWithConnectionPool accessMode pool = interpret $ \env -> \case
-  WithConnection f -> do
-    loggerEnv <- getLoggerEnv
-    localSeqUnlift env $ \unlift -> do
-      unliftedWithResource accessMode loggerEnv pool $ unlift . f
+transactionMode :: AccessMode -> PGTransaction.TransactionMode
+transactionMode ReadOnly =
+  PGTransaction.TransactionMode PGTransaction.defaultIsolationLevel PGTransaction.ReadOnly
+transactionMode ReadWrite =
+  PGTransaction.TransactionMode PGTransaction.defaultIsolationLevel PGTransaction.ReadWrite
 
 unliftedWithResource
   :: MonadUnliftIO m
@@ -84,59 +203,3 @@ unliftedWithResource accessMode loggerEnv pool action = withRunInIO $ \io ->
             , "access_mode" .= display accessMode
             ]
     io $ action resource.resource
-
-withReadWritePool
-  :: forall a es
-   . (IOE :> es, Log :> es)
-  => Pool PG.Connection
-  -> Eff (Labeled ReadWrite WithConnection ': es) a
-  -> FloraM es a
-withReadWritePool pool action = do
-  runLabeled (withPool ReadWrite pool) action
-
-withReadOnlyPool
-  :: forall a es
-   . (IOE :> es, Log :> es)
-  => Pool PG.Connection
-  -> Eff (Labeled ReadOnly WithConnection ': es) a
-  -> FloraM es a
-withReadOnlyPool pool action = do
-  runLabeled (withPool ReadOnly pool) action
-
-queryOne
-  :: ( HasCallStack
-     , IOE :> es
-     , Labeled ReadOnly WithConnection :> es
-     , PG.FromRow result
-     , PG.ToRow params
-     )
-  => PG.Query
-  -> params
-  -> Eff es (Maybe result)
-queryOne q params =
-  labeled @ReadOnly @WithConnection $
-    listToMaybe <$> DB.query q params
-
-queryOne_
-  :: ( HasCallStack
-     , IOE :> es
-     , Labeled ReadOnly WithConnection :> es
-     , PG.FromRow result
-     )
-  => PG.Query
-  -> Eff es (Maybe result)
-queryOne_ q =
-  labeled @ReadOnly @WithConnection $
-    listToMaybe <$> DB.query_ q
-
-upsert
-  :: forall e es values
-   . (Entity e, IOE :> es, Labeled ReadWrite WithConnection :> es, ToRow values)
-  => values
-  -- ^ Entity to insert
-  -> Vector Field
-  -- ^ Fields to replace in case of conflict
-  -> Eff es ()
-upsert entity fieldsToReplace = void $ labeled @ReadWrite @WithConnection $ DB.execute (_insert @e <> _onConflictDoUpdate conflictTarget fieldsToReplace) entity
-  where
-    conflictTarget = Vector.singleton $ primaryKey @e

--- a/src/core/Flora/Import/Package.hs
+++ b/src/core/Flora/Import/Package.hs
@@ -59,13 +59,9 @@ import Distribution.Utils.ShortText (fromShortText)
 import Distribution.Version (Version, VersionRange, withinRange)
 import Distribution.Version qualified as Version
 import Effectful
-import Effectful.Concurrent (Concurrent)
-import Effectful.Concurrent.Async qualified as Concurrent
 import Effectful.Error.Static (Error)
 import Effectful.Error.Static qualified as Error
-import Effectful.Labeled
 import Effectful.Log (Log)
-import Effectful.PostgreSQL
 import Effectful.Reader.Static (Reader)
 import Effectful.Reader.Static qualified as Reader
 import Effectful.State.Static.Shared (State)
@@ -80,7 +76,6 @@ import System.Exit (exitFailure)
 import System.FilePath qualified as FilePath
 
 import Flora.Database
-import Flora.Environment.Config (PoolConfig (..))
 import Flora.Environment.Env (FloraEnv (..))
 import Flora.Import.Package.Types
 import Flora.Import.Types
@@ -275,8 +270,7 @@ parseString parser name bs = do
 --  by extracting relevant information from a Cabal file using 'extractPackageDataFromCabal'
 persistImportOutput
   :: forall es
-   . ( Concurrent :> es
-     , IOE :> es
+   . ( IOE :> es
      , Log :> es
      , Reader FloraEnv :> es
      , RequireCallStack
@@ -292,7 +286,7 @@ persistImportOutput (ImportOutput package categories release components) = State
     ]
     $ do
       env <- Reader.ask
-      withReadWritePool env.pool . withReadOnlyPool env.pool $ do
+      withReadWritePool env.pool $ do
         Update.upsertPackage package
         categoriesByName <- catMaybes <$> traverse Query.getCategoryByName categories
         forM_
@@ -314,14 +308,13 @@ persistImportOutput (ImportOutput package categories release components) = State
             let dependencyPackages = fmap (.package) dependencies
             Update.upsertPackageComponents componentsList
             Log.logInfo_ "Inserting dependencies"
-            Concurrent.pooledForConcurrentlyN_
-              env.dbConfig.connections
+            forM_
               dependencyPackages
               ( \p -> do
                   Log.logInfo_ "Upserting package"
                   Update.upsertPackage p
               )
-            Concurrent.pooledForConcurrentlyN_ env.dbConfig.connections dependencies persistImportDependency
+            forM_ dependencies persistImportDependency
             unless (null dependencies) sanityCheck
             pure $ Set.insert (package.namespace, package.name, release.version) packageCache
   where
@@ -338,8 +331,7 @@ persistImportOutput (ImportOutput package categories release components) = State
       Update.upsertRequirement dep.requirement
 
     sanityCheck = do
-      FloraEnv{pool} <- Reader.ask
-      dependencies <- withReadOnlyPool pool $ Query.getAllRequirements release.releaseId
+      dependencies <- Query.getAllRequirements release.releaseId
       when (Map.null dependencies) $ do
         Log.logAttention "No dependencies found after inserting release!" $
           object
@@ -351,10 +343,10 @@ persistImportOutput (ImportOutput package categories release components) = State
 
 persistHashes
   :: ( IOE :> es
-     , Labeled ReadOnly WithConnection :> es
-     , Labeled ReadWrite WithConnection :> es
      , Log :> es
+     , ReadDB :> es
      , State (Map (Namespace, PackageName, Version) Text) :> es
+     , WriteDB :> es
      )
   => (Namespace, PackageName, Version, Target)
   -> FloraM es ()
@@ -427,7 +419,9 @@ extractPackageDataFromCabal packageIndex indexPackages uploadTime mUsername gene
       let rawCategoryField = packageDesc ^. #category % to fromShortText % to Text.pack
       let categoryList = fmap (Text.stripStart . Text.stripEnd) (Text.splitOn "," rawCategoryField)
       let categories = Maybe.mapMaybe normaliseCategory categoryList
-      mPackageUploaderId <- withReadOnlyPool pool $ withReadWritePool pool $ determinePackageUploaderId mUsername packageIndex.packageIndexId
+      mPackageUploaderId <- case mUsername of
+        Nothing -> pure Nothing
+        Just username -> withReadWritePool pool $ determinePackageUploaderId (Just username) packageIndex.packageIndexId
       let package =
             Package
               { packageId
@@ -515,7 +509,7 @@ extractPackageDataFromCabal packageIndex indexPackages uploadTime mUsername gene
           extractPackageDataFromCabal packageIndex indexPackages uploadTime mUsername genericDesc
         Just components -> pure $ ImportOutput package categories release components
 
-determinePackageUploaderId :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Labeled ReadWrite WithConnection :> es) => Maybe Text -> PackageIndexId -> Eff es (Maybe PackageUploaderId)
+determinePackageUploaderId :: (IOE :> es, ReadDB :> es, WriteDB :> es) => Maybe Text -> PackageIndexId -> Eff es (Maybe PackageUploaderId)
 determinePackageUploaderId Nothing _ = pure Nothing
 determinePackageUploaderId (Just username) packageIndexId = Just <$> Update.getOrInsertPackageUploader username packageIndexId
 

--- a/src/core/Flora/Model/BlobIndex/Query.hs
+++ b/src/core/Flora/Model/BlobIndex/Query.hs
@@ -16,9 +16,7 @@ import Database.PostgreSQL.Entity.Types (SortKeyword (..), field)
 import Database.PostgreSQL.Simple (Only (..))
 import Distribution.Version (Version)
 import Effectful
-import Effectful.Labeled
 import Effectful.Log (Log)
-import Effectful.PostgreSQL
 import Log qualified
 
 import Flora.Database
@@ -31,7 +29,7 @@ import Flora.Model.Package.Types (PackageName)
 -- from the database
 queryTar
   :: forall es
-   . (BlobStoreAPI :> es, IOE :> es, Labeled ReadOnly WithConnection :> es, Log :> es)
+   . (BlobStoreAPI :> es, IOE :> es, Log :> es, ReadDB :> es)
   => PackageName
   -> Version
   -> Sha256Sum
@@ -44,15 +42,14 @@ queryTar pname version rootHash = do
   where
     queryChildren :: Sha256Sum -> Eff es (V.Vector BlobRelation)
     queryChildren hash =
-      labeled @ReadOnly @WithConnection $
-        Vector.fromList
-          <$> query
-            ( _selectWhere @BlobRelation [[field| blob_hash |]]
-                -- Ensures we consistently get back the directory structure
-                -- This may not be the same as the hackage tarball!
-                <> _orderBy ([field| blob_dep_path |], ASC)
-            )
-            (Only hash)
+      Vector.fromList
+        <$> query
+          ( _selectWhere @BlobRelation [[field| blob_hash |]]
+              -- Ensures we consistently get back the directory structure
+              -- This may not be the same as the hackage tarball!
+              <> _orderBy ([field| blob_dep_path |], ASC)
+          )
+          (Only hash)
     go :: BlobRelation -> Eff es (FilePath, TarTree Sha256Sum)
     go (BlobRelation _blobHash blobDepHash blobDepPath blobDepDirectory)
       | blobDepDirectory =

--- a/src/core/Flora/Model/BlobIndex/Update.hs
+++ b/src/core/Flora/Model/BlobIndex/Update.hs
@@ -11,15 +11,10 @@ import Database.PostgreSQL.Simple (ToRow)
 import Database.PostgreSQL.Simple.Types (Query)
 import Distribution.Version (Version)
 import Effectful
-import Effectful.Labeled
 import Effectful.Log (Log)
-import Effectful.PostgreSQL
-import Effectful.Reader.Static (Reader)
-import Effectful.Reader.Static qualified as Reader
 import Log qualified
 
 import Flora.Database
-import Flora.Environment.Env
 import Flora.Model.BlobIndex.Internal
 import Flora.Model.BlobIndex.Types
 import Flora.Model.BlobStore.API
@@ -31,15 +26,14 @@ import Flora.Model.Release.Update qualified as Update
 import Flora.Monad
 
 insertTar
-  :: (BlobStoreAPI :> es, IOE :> es, Labeled ReadWrite WithConnection :> es, Log :> es, Reader FloraEnv :> es)
+  :: (BlobStoreAPI :> es, IOE :> es, Log :> es, ReadDB :> es, WriteDB :> es)
   => Namespace
   -> PackageName
   -> Version
   -> LazyByteString
   -> FloraM es (Either BlobStoreInsertError Sha256Sum)
 insertTar namespace packageName version contents = do
-  FloraEnv{pool} <- Reader.ask
-  lookups <- withReadOnlyPool pool $ do
+  lookups <- do
     mpackage <- Query.getPackageByNamespaceAndName namespace packageName
     case mpackage of
       Nothing -> pure . Left $ NoPackage packageName
@@ -62,7 +56,7 @@ insertTar namespace packageName version contents = do
         Right t@(TarRoot rootHash _ _ _) -> Right rootHash <$ insertTree release.releaseId t
 
 insertTree
-  :: (BlobStoreAPI :> es, IOE :> es, Labeled ReadWrite WithConnection :> es, Log :> es, Reader FloraEnv :> es)
+  :: (BlobStoreAPI :> es, IOE :> es, Log :> es, WriteDB :> es)
   => ReleaseId
   -> TarRoot Sha256Sum
   -> FloraM es ()
@@ -76,8 +70,8 @@ insertTree releaseId (TarRoot rootHash _ _ tree) = do
     _onConflictDoNothing :: Query
     _onConflictDoNothing = fromString "on conflict do nothing"
 
-    insertDoNothing :: forall e es. (Entity e, IOE :> es, Labeled ReadWrite WithConnection :> es, ToRow e) => e -> Eff es Int64
-    insertDoNothing params = labeled @ReadWrite @WithConnection $ execute (_insert @e <> _onConflictDoNothing) params
+    insertDoNothing :: forall e es. (Entity e, IOE :> es, ToRow e, WriteDB :> es) => e -> Eff es Int64
+    insertDoNothing params = execute (_insert @e <> _onConflictDoNothing) params
 
     insertBlobs parentHash dir (TarDirectory childHash nodes) = do
       res <- insertDoNothing $! BlobRelation parentHash childHash dir True

--- a/src/core/Flora/Model/Category/Query.hs
+++ b/src/core/Flora/Model/Category/Query.hs
@@ -12,23 +12,21 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Entity.Types (field)
 import Database.PostgreSQL.Simple (Only (..))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Category.Types
 import Flora.Model.Package.Types
 
-getCategoryById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => CategoryId -> Eff es (Maybe Category)
-getCategoryById categoryId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Category [primaryKey @Category]) (Only categoryId)
+getCategoryById :: (IOE :> es, ReadDB :> es) => CategoryId -> Eff es (Maybe Category)
+getCategoryById categoryId = queryOne (_selectWhere @Category [primaryKey @Category]) (Only categoryId)
 
-getCategoryBySlug :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Maybe Category)
-getCategoryBySlug slug = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Category [[field| slug |]]) (Only slug)
+getCategoryBySlug :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Maybe Category)
+getCategoryBySlug slug = queryOne (_selectWhere @Category [[field| slug |]]) (Only slug)
 
-getCategoryByName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Maybe Category)
-getCategoryByName categoryName = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Category [[field| name |]]) (Only categoryName)
+getCategoryByName :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Maybe Category)
+getCategoryByName categoryName = queryOne (_selectWhere @Category [[field| name |]]) (Only categoryName)
 
-getPackagesFromCategorySlug :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Vector Package)
+getPackagesFromCategorySlug :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Vector Package)
 getPackagesFromCategorySlug slug =
   do
     getCategoryBySlug slug
@@ -37,9 +35,8 @@ getPackagesFromCategorySlug slug =
         liftIO $ T.putStrLn $ "Could not find category from slug: \"" <> slug <> "\""
         pure Vector.empty
       Just Category{categoryId} -> do
-        labeled @ReadOnly @WithConnection $
-          Vector.fromList
-            <$> query (_joinSelectOneByField @Package @PackageCategory [field| package_id |] [field| category_id |]) (Only categoryId)
+        Vector.fromList
+          <$> query (_joinSelectOneByField @Package @PackageCategory [field| package_id |] [field| category_id |]) (Only categoryId)
 
-getAllCategories :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector Category)
-getAllCategories = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ (_select @Category)
+getAllCategories :: ReadDB :> es => Eff es (Vector Category)
+getAllCategories = Vector.fromList <$> query_ (_select @Category)

--- a/src/core/Flora/Model/Category/Update.hs
+++ b/src/core/Flora/Model/Category/Update.hs
@@ -8,21 +8,16 @@ import Data.Text (Text)
 import Data.Text.IO qualified as T
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
-import Effectful.Reader.Static (Reader)
-import Effectful.Reader.Static qualified as Reader
 
 import Flora.Database
-import Flora.Environment.Env
 import Flora.Model.Category.Query qualified as Query
 import Flora.Model.Category.Types
 import Flora.Model.Package.Types
 import Flora.Monad
 
-insertCategory :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Category -> Eff es ()
+insertCategory :: WriteDB :> es => Category -> Eff es ()
 insertCategory category = do
-  labeled @_ @WithConnection $ void $ execute q category
+  void $ execute q category
   where
     q =
       [sql|
@@ -32,8 +27,8 @@ insertCategory category = do
         |]
 
 -- | Adds a package to a category. Adding a package to an already-assigned category has no effect
-addToCategory :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => PackageId -> CategoryId -> Eff es ()
-addToCategory packageId categoryId = labeled @_ @WithConnection $ (void . execute q) (packageId, categoryId)
+addToCategory :: (IOE :> es, WriteDB :> es) => PackageId -> CategoryId -> Eff es ()
+addToCategory packageId categoryId = (void . execute q) (packageId, categoryId)
   where
     q =
       [sql|
@@ -41,10 +36,9 @@ addToCategory packageId categoryId = labeled @_ @WithConnection $ (void . execut
         on conflict do nothing
       |]
 
-addToCategoryByName :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Reader FloraEnv :> es) => PackageId -> Text -> FloraM es ()
+addToCategoryByName :: (IOE :> es, ReadDB :> es, WriteDB :> es) => PackageId -> Text -> FloraM es ()
 addToCategoryByName packageId categoryName = do
-  FloraEnv{pool} <- Reader.ask
-  mCategory <- withReadOnlyPool pool $ Query.getCategoryByName categoryName
+  mCategory <- Query.getCategoryByName categoryName
   case mCategory of
     Nothing -> do
       liftIO $ T.putStrLn ("Could not find category " <> categoryName)

--- a/src/core/Flora/Model/Component/Query.hs
+++ b/src/core/Flora/Model/Component/Query.hs
@@ -10,22 +10,19 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Entity.Types
 import Database.PostgreSQL.Simple (Only (..))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Component.Types
 import Flora.Model.Release.Types (ReleaseId)
 
-getComponentsByReleaseId :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> Eff es (Vector CanonicalComponent)
+getComponentsByReleaseId :: (IOE :> es, ReadDB :> es) => ReleaseId -> Eff es (Vector CanonicalComponent)
 getComponentsByReleaseId releaseId = do
   (results :: Vector (Text, ComponentType)) <-
-    labeled @ReadOnly @WithConnection $
-      Vector.fromList
-        <$> query
-          ( _selectWithFields @PackageComponent
-              [[field| component_name |], [field| component_type |]]
-              <> _where [[field| release_id |]]
-          )
-          (Only releaseId)
+    Vector.fromList
+      <$> query
+        ( _selectWithFields @PackageComponent
+            [[field| component_name |], [field| component_type |]]
+            <> _where [[field| release_id |]]
+        )
+        (Only releaseId)
   pure $ fmap (uncurry CanonicalComponent) results

--- a/src/core/Flora/Model/Feed/Query.hs
+++ b/src/core/Flora/Model/Feed/Query.hs
@@ -8,15 +8,13 @@ import Data.Vector qualified as Vector
 import Database.PostgreSQL.Simple (In (..))
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Feed.Types
 import Flora.Model.Package.Types
 
 getEntriesByPackage
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => List (Namespace, PackageName)
   -> Word
   -- ^ Offset
@@ -24,7 +22,7 @@ getEntriesByPackage
   -- ^ Limit
   -> Eff es (Vector FeedEntry)
 getEntriesByPackage packages offset limit = do
-  labeled @ReadOnly @WithConnection $ Vector.fromList <$> query querySpec (In packages, offset, limit)
+  Vector.fromList <$> query querySpec (In packages, offset, limit)
   where
     querySpec =
       [sql|

--- a/src/core/Flora/Model/Feed/Update.hs
+++ b/src/core/Flora/Model/Feed/Update.hs
@@ -5,20 +5,17 @@ import Data.Time
 import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Simple (Only (Only))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Feed.Types
 
-insertFeedEntry :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => FeedEntry -> Eff es ()
+insertFeedEntry :: (IOE :> es, WriteDB :> es) => FeedEntry -> Eff es ()
 insertFeedEntry entry =
-  void $ labeled @ReadWrite @WithConnection $ execute (_insert @FeedEntry) entry
+  void $ execute (_insert @FeedEntry) entry
 
-deleteEntriesBefore :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => UTCTime -> Eff es ()
+deleteEntriesBefore :: (IOE :> es, WriteDB :> es) => UTCTime -> Eff es ()
 deleteEntriesBefore date =
   void $
-    labeled @ReadWrite @WithConnection $
-      execute
-        "DELETE FROM package_feeds WHERE created_at < ?"
-        (Only date)
+    execute
+      "DELETE FROM package_feeds WHERE created_at < ?"
+      (Only date)

--- a/src/core/Flora/Model/Organisation.hs
+++ b/src/core/Flora/Model/Organisation.hs
@@ -19,8 +19,6 @@ import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Database.PostgreSQL.Simple.ToField (ToField (..))
 import Database.PostgreSQL.Simple.ToRow (ToRow (..))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import GHC.Generics
 
 import Flora.Database
@@ -59,35 +57,35 @@ data UserOrganisation = UserOrganisation
     (Entity)
     via (GenericEntity '[TableName "user_organisation"] UserOrganisation)
 
-insertOrganisation :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Organisation -> Eff es ()
-insertOrganisation org = void $ labeled @ReadWrite @WithConnection $ execute (_insert @Organisation) org
+insertOrganisation :: (IOE :> es, WriteDB :> es) => Organisation -> Eff es ()
+insertOrganisation org = void $ execute (_insert @Organisation) org
 
-getOrganisationById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => OrganisationId -> Eff es (Maybe Organisation)
-getOrganisationById orgId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Organisation [primaryKey @Organisation]) (Only orgId)
+getOrganisationById :: (IOE :> es, ReadDB :> es) => OrganisationId -> Eff es (Maybe Organisation)
+getOrganisationById orgId = queryOne (_selectWhere @Organisation [primaryKey @Organisation]) (Only orgId)
 
-getOrganisationByName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Maybe Organisation)
-getOrganisationByName name = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Organisation [[field| organisation_name |]]) (Only name)
+getOrganisationByName :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Maybe Organisation)
+getOrganisationByName name = queryOne (_selectWhere @Organisation [[field| organisation_name |]]) (Only name)
 
-deleteOrganisation :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => OrganisationId -> Eff es ()
-deleteOrganisation orgId = void $ labeled @ReadOnly @WithConnection $ execute (_delete @Organisation) (Only orgId)
+deleteOrganisation :: (IOE :> es, WriteDB :> es) => OrganisationId -> Eff es ()
+deleteOrganisation orgId = void $ execute (_delete @Organisation) (Only orgId)
 
-getAllUserOrganisations :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector UserOrganisation)
-getAllUserOrganisations = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ (_select @UserOrganisation)
+getAllUserOrganisations :: (IOE :> es, ReadDB :> es) => Eff es (Vector UserOrganisation)
+getAllUserOrganisations = Vector.fromList <$> query_ (_select @UserOrganisation)
 
-getUserOrganisationById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => UserOrganisationId -> Eff es (Maybe UserOrganisation)
-getUserOrganisationById uoId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @UserOrganisation [primaryKey @Organisation]) (Only uoId)
+getUserOrganisationById :: (IOE :> es, ReadDB :> es) => UserOrganisationId -> Eff es (Maybe UserOrganisation)
+getUserOrganisationById uoId = queryOne (_selectWhere @UserOrganisation [primaryKey @Organisation]) (Only uoId)
 
-getUserOrganisation :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => UserId -> OrganisationId -> Eff es (Maybe UserOrganisation)
-getUserOrganisation userId orgId = labeled @ReadOnly @WithConnection $ queryOne q (userId, orgId)
+getUserOrganisation :: (IOE :> es, ReadDB :> es) => UserId -> OrganisationId -> Eff es (Maybe UserOrganisation)
+getUserOrganisation userId orgId = queryOne q (userId, orgId)
   where
     q = _selectWhere @UserOrganisation [[field| user_id |], [field| organisation_id |]]
 
-attachUser :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => UserId -> OrganisationId -> UserOrganisationId -> Eff es ()
+attachUser :: (IOE :> es, WriteDB :> es) => UserId -> OrganisationId -> UserOrganisationId -> Eff es ()
 attachUser userId organisationId uoId = do
-  void $ labeled @ReadOnly @WithConnection $ execute (_insert @UserOrganisation) (UserOrganisation uoId userId organisationId False)
+  void $ execute (_insert @UserOrganisation) (UserOrganisation uoId userId organisationId False)
 
-getUsers :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => OrganisationId -> Eff es (Vector User)
-getUsers orgId = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query q (Only orgId)
+getUsers :: (IOE :> es, ReadDB :> es) => OrganisationId -> Eff es (Vector User)
+getUsers orgId = Vector.fromList <$> query q (Only orgId)
   where
     q =
       [sql|
@@ -98,8 +96,8 @@ getUsers orgId = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query q
         WHERE uo.organisation_id = ?
         |]
 
-getAdmins :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => OrganisationId -> Eff es (Vector User)
-getAdmins orgId = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query q (Only orgId)
+getAdmins :: (IOE :> es, ReadDB :> es) => OrganisationId -> Eff es (Vector User)
+getAdmins orgId = Vector.fromList <$> query q (Only orgId)
   where
     q =
       [sql|

--- a/src/core/Flora/Model/Package/Guard.hs
+++ b/src/core/Flora/Model/Package/Guard.hs
@@ -1,8 +1,6 @@
 module Flora.Model.Package.Guard where
 
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Effectful.Tracing (Tracer)
 import Effectful.Tracing qualified as Trace
 
@@ -11,7 +9,7 @@ import Flora.Model.Package.Query qualified as Query
 import Flora.Model.Package.Types
 
 guardThatPackageExists
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Tracer :> es)
+  :: (IOE :> es, ReadDB :> es, Tracer :> es)
   => Namespace
   -> PackageName
   -> (Namespace -> PackageName -> Eff es Package)

--- a/src/core/Flora/Model/Package/Query.hs
+++ b/src/core/Flora/Model/Package/Query.hs
@@ -50,9 +50,7 @@ import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Database.PostgreSQL.Simple.Types
 import Distribution.Version (Version)
 import Effectful (Eff, IOE, type (:>))
-import Effectful.Labeled
 import Effectful.Log (Log)
-import Effectful.PostgreSQL
 import Log qualified
 import Optics.Core ((&), (^.))
 
@@ -75,73 +73,60 @@ withTotalCount rows =
   , Vector.fromList [x | (x :. _) <- rows]
   )
 
-getAllPackages :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector Package)
-getAllPackages = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ (_select @Package)
+getAllPackages :: (IOE :> es, ReadDB :> es) => Eff es (Vector Package)
+getAllPackages = Vector.fromList <$> query_ (_select @Package)
 
-getPackageById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> Eff es (Maybe Package)
-getPackageById packageId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Package [primaryKey @Package]) (Only packageId)
+getPackageById :: (IOE :> es, ReadDB :> es) => PackageId -> Eff es (Maybe Package)
+getPackageById packageId = queryOne (_selectWhere @Package [primaryKey @Package]) (Only packageId)
 
-getPackagesByNamespace :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Namespace -> Eff es (Vector Package)
-getPackagesByNamespace namespace = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query (_selectWhere @Package [[field| namespace |]]) (Only namespace)
+getPackagesByNamespace :: (IOE :> es, ReadDB :> es) => Namespace -> Eff es (Vector Package)
+getPackagesByNamespace namespace = Vector.fromList <$> query (_selectWhere @Package [[field| namespace |]]) (Only namespace)
 
-getPackageByNamespaceAndName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Namespace -> PackageName -> Eff es (Maybe Package)
+getPackageByNamespaceAndName :: (IOE :> es, ReadDB :> es) => Namespace -> PackageName -> Eff es (Maybe Package)
 getPackageByNamespaceAndName namespace name =
-  labeled @ReadOnly @WithConnection $
-    queryOne
-      (_selectWhere @Package [[field| namespace |], [field| name |]])
-      (namespace, name)
+  queryOne
+    (_selectWhere @Package [[field| namespace |], [field| name |]])
+    (namespace, name)
 
-getNonDeprecatedPackages :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector Package)
-getNonDeprecatedPackages = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ (_selectWhereNull @Package [[field| deprecation_info |]])
+getNonDeprecatedPackages :: (IOE :> es, ReadDB :> es) => Eff es (Vector Package)
+getNonDeprecatedPackages = Vector.fromList <$> query_ (_selectWhereNull @Package [[field| deprecation_info |]])
 
 getAllPackageDependents
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Namespace
   -> PackageName
   -> Eff es (Vector Package)
 getAllPackageDependents namespace packageName =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList <$> query packageDependentsQuery (namespace, packageName)
+  Vector.fromList <$> query packageDependentsQuery (namespace, packageName)
 
 getPackageDependentsByName
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Namespace
   -> PackageName
   -> Text
   -> Eff es (Vector Package)
 getPackageDependentsByName namespace packageName searchString =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query
-        searchPackageDependentsQuery
-        (namespace, packageName, searchString)
+  Vector.fromList
+    <$> query
+      searchPackageDependentsQuery
+      (namespace, packageName, searchString)
 
 -- | This function gets the first 6 dependents of a package
-getPackageDependents :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Namespace -> PackageName -> Eff es (Vector Package)
-getPackageDependents namespace packageName = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query q (namespace, packageName)
+getPackageDependents :: (IOE :> es, ReadDB :> es) => Namespace -> PackageName -> Eff es (Vector Package)
+getPackageDependents namespace packageName = Vector.fromList <$> query q (namespace, packageName)
   where
     q = packageDependentsQuery <> " LIMIT 6"
 
 getNumberOfPackageDependents
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Namespace
   -> PackageName
   -> Maybe Text
   -> Eff es Word
-getNumberOfPackageDependents namespace packageName mbSearchString = labeled @ReadOnly @WithConnection $ do
+getNumberOfPackageDependents namespace packageName mbSearchString =
   case mbSearchString of
-    Nothing ->
-      do
-        (result :: Maybe (Only Int)) <- queryOne numberOfPackageDependentsQuery (namespace, packageName)
-        case result of
-          Just (Only n) -> pure $ fromIntegral n
-          Nothing -> pure 0
-    Just searchString ->
-      do
-        (result :: Maybe (Only Int)) <- queryOne searchNumberOfPackageDependentsQuery (namespace, packageName, searchString)
-        case result of
-          Just (Only n) -> pure $ fromIntegral n
-          Nothing -> pure 0
+    Nothing -> queryCount numberOfPackageDependentsQuery (namespace, packageName)
+    Just searchString -> queryCount searchNumberOfPackageDependentsQuery (namespace, packageName, searchString)
 
 numberOfPackageDependentsQuery :: Query
 numberOfPackageDependentsQuery =
@@ -189,22 +174,21 @@ searchPackageDependentsQuery =
   packageDependentsQuery <> " AND ? <% p.name"
 
 getAllPackageDependentsWithLatestVersion
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Namespace
   -> PackageName
   -> (Word, Word)
   -> Maybe Text
   -> Eff es (Vector DependencyInfo)
-getAllPackageDependentsWithLatestVersion namespace packageName (offset, limit) mSearchString = labeled @ReadOnly @WithConnection $
-  case mSearchString of
-    Nothing ->
-      Vector.fromList <$> query q (namespace, packageName, offset, limit)
-      where
-        q = packageDependentsWithLatestVersionQuery <> " OFFSET ? LIMIT ?"
-    Just searchString ->
-      Vector.fromList <$> query q (namespace, packageName, searchString, offset, limit)
-      where
-        q = searchPackageDependentsWithLatestVersionQuery <> " OFFSET ? LIMIT ?"
+getAllPackageDependentsWithLatestVersion namespace packageName (offset, limit) mSearchString = case mSearchString of
+  Nothing ->
+    Vector.fromList <$> query q (namespace, packageName, offset, limit)
+    where
+      q = packageDependentsWithLatestVersionQuery <> " OFFSET ? LIMIT ?"
+  Just searchString ->
+    Vector.fromList <$> query q (namespace, packageName, searchString, offset, limit)
+    where
+      q = searchPackageDependentsWithLatestVersionQuery <> " OFFSET ? LIMIT ?"
 
 packageDependentsWithLatestVersionQuery :: Query
 packageDependentsWithLatestVersionQuery =
@@ -276,13 +260,12 @@ FROM dependents AS d
 WHERE rank = 1
     |]
 
-getComponentById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ComponentId -> Eff es (Maybe PackageComponent)
+getComponentById :: (IOE :> es, ReadDB :> es) => ComponentId -> Eff es (Maybe PackageComponent)
 getComponentById componentId = queryOne (_selectWhere @PackageComponent [primaryKey @PackageComponent]) (Only componentId)
 
-getComponent :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> Text -> ComponentType -> Eff es (Maybe PackageComponent)
+getComponent :: (IOE :> es, ReadDB :> es) => ReleaseId -> Text -> ComponentType -> Eff es (Maybe PackageComponent)
 getComponent releaseId name componentType =
-  labeled @ReadOnly @WithConnection $
-    queryOne (_selectWhere @PackageComponent queryFields) (releaseId, name, componentType)
+  queryOne (_selectWhere @PackageComponent queryFields) (releaseId, name, componentType)
   where
     queryFields :: Vector Field
     queryFields =
@@ -292,33 +275,31 @@ getComponent releaseId name componentType =
       ]
 
 unsafeGetComponent
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => ReleaseId
   -> Eff es (Maybe PackageComponent)
 unsafeGetComponent releaseId =
-  labeled @ReadOnly @WithConnection $
-    queryOne (_selectWhere @PackageComponent queryFields) (Only releaseId)
+  queryOne (_selectWhere @PackageComponent queryFields) (Only releaseId)
   where
     queryFields :: Vector Field
     queryFields = [[field| release_id |]]
 
 getAllRequirements
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => ReleaseId
   -> Eff es ComponentDependencies
 getAllRequirements releaseId =
-  labeled @ReadOnly @WithConnection $
-    query getAllRequirementsQuery (Only releaseId) <&> toComponentDependencies . Vector.fromList
+  query getAllRequirementsQuery (Only releaseId) <&> toComponentDependencies . Vector.fromList
 
 -- | This function has a bit of logic where if there exists a component with the same name as the package,
 -- this component's dependencies are chosen.
 -- Otherwise, requirements without discrimination by component are fetched.
 getRequirements
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageName
   -> ReleaseId
   -> Eff es (Vector DependencyVersionRequirement)
-getRequirements (PackageName packageName) releaseId = labeled @ReadOnly @WithConnection $ do
+getRequirements (PackageName packageName) releaseId = do
   components <- Query.getComponentsByReleaseId releaseId
   results <- case Vector.find (\CanonicalComponent{componentName} -> componentName == packageName) components of
     Just (CanonicalComponent{componentType}) ->
@@ -409,12 +390,8 @@ getRequirementsQuery singleComponentType =
       ORDER BY dependency.namespace DESC, LOWER(dependency.name) ASC
       |]
 
-getNumberOfPackageRequirements :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> Eff es Word
-getNumberOfPackageRequirements releaseId = labeled @ReadOnly @WithConnection $ do
-  (result :: Maybe (Only Int)) <- queryOne numberOfPackageRequirementsQuery (Only releaseId)
-  case result of
-    Just (Only n) -> pure $ fromIntegral n
-    Nothing -> pure 0
+getNumberOfPackageRequirements :: (IOE :> es, ReadDB :> es) => ReleaseId -> Eff es Word
+getNumberOfPackageRequirements releaseId = queryCount numberOfPackageRequirementsQuery (Only releaseId)
 
 numberOfPackageRequirementsQuery :: Query
 numberOfPackageRequirementsQuery =
@@ -430,24 +407,23 @@ WHERE rel.release_id = ?
 |]
 
 getPackageCategories
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> Eff es (Vector Category)
 getPackageCategories packageId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query
-        ( _joinSelectOneByField @Category @PackageCategory
-            [field| category_id |]
-            [field| package_id |]
-        )
-        (Only packageId)
+  Vector.fromList
+    <$> query
+      ( _joinSelectOneByField @Category @PackageCategory
+          [field| category_id |]
+          [field| package_id |]
+      )
+      (Only packageId)
 
 getPackagesFromCategoryWithLatestVersion
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => CategoryId
   -> Eff es (Vector PackageInfo)
-getPackagesFromCategoryWithLatestVersion categoryId = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query q (Only categoryId)
+getPackagesFromCategoryWithLatestVersion categoryId = Vector.fromList <$> query q (Only categoryId)
   where
     q =
       [sql|
@@ -467,15 +443,14 @@ getPackagesFromCategoryWithLatestVersion categoryId = labeled @ReadOnly @WithCon
       |]
 
 searchPackage
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => (Word, Word)
   -> Text
   -> Eff es (Word, Vector PackageInfo)
 searchPackage (offset, limit) searchString =
-  labeled @ReadOnly @WithConnection $
-    withTotalCount
-      <$> query
-        [sql|
+  withTotalCount
+    <$> query
+      [sql|
         SELECT  lv."package_id"
               , lv."namespace"
               , lv."name"
@@ -502,19 +477,18 @@ searchPackage (offset, limit) searchString =
         LIMIT ?
         ;
         |]
-        (searchString, searchString, offset, limit)
+      (searchString, searchString, offset, limit)
 
 searchPackageByNamespace
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => (Word, Word)
   -> Namespace
   -> Text
   -> Eff es (Word, Vector PackageInfo)
 searchPackageByNamespace (offset, limit) namespace searchString =
-  labeled @ReadOnly @WithConnection $
-    withTotalCount
-      <$> query
-        [sql|
+  withTotalCount
+    <$> query
+      [sql|
         SELECT  lv."package_id"
               , lv."namespace"
               , lv."name"
@@ -543,18 +517,17 @@ searchPackageByNamespace (offset, limit) namespace searchString =
         OFFSET ?
         ;
         |]
-        (searchString, searchString, namespace, limit, offset)
+      (searchString, searchString, namespace, limit, offset)
 
 searchExecutable
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => (Word, Word)
   -> Text
   -> Eff es (Vector PackageInfoWithExecutables)
 searchExecutable (offset, limit) searchString =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query
-        [sql|
+  Vector.fromList
+    <$> query
+      [sql|
 WITH results AS (SELECT DISTINCT l2.namespace
                       , l2.name
                       , l2.synopsis
@@ -584,14 +557,12 @@ WITH results AS (SELECT DISTINCT l2.namespace
 LIMIT ?
 OFFSET ?
         |]
-        (searchString, searchString, limit, offset)
+      (searchString, searchString, limit, offset)
 
-getNumberOfExecutablesByName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es Word
-getNumberOfExecutablesByName queryString = do
-  do
-    (result :: Maybe (Only Int)) <-
-      queryOne
-        [sql|
+getNumberOfExecutablesByName :: (IOE :> es, ReadDB :> es) => Text -> Eff es Word
+getNumberOfExecutablesByName queryString =
+  queryCount
+    [sql|
 WITH results AS (SELECT l2.name
                       , word_similarity(p0.component_name, ?) AS rating
                       , p0.component_name
@@ -609,21 +580,17 @@ WITH results AS (SELECT l2.name
   SELECT count(e.*)
   FROM executables AS e
           |]
-        (queryString, queryString)
-    case result of
-      Just (Only n) -> pure $ fromIntegral n
-      Nothing -> pure 0
+    (queryString, queryString)
 
 -- | Returns a summary of packages
 listAllPackages
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => (Word, Word)
   -> Eff es (Word, Vector PackageInfo)
 listAllPackages (offset, limit) =
-  labeled @ReadOnly @WithConnection $
-    withTotalCount
-      <$> query
-        [sql|
+  withTotalCount
+    <$> query
+      [sql|
     SELECT  lv."package_id"
           , lv."namespace"
           , lv."name"
@@ -651,18 +618,17 @@ listAllPackages (offset, limit) =
     LIMIT ?
     ;
     |]
-        (offset, limit)
+      (offset, limit)
 
 listAllPackagesInNamespace
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => (Word, Word)
   -> Namespace
   -> Eff es (Word, Vector PackageInfo)
 listAllPackagesInNamespace (offset, limit) namespace =
-  labeled @ReadOnly @WithConnection $
-    withTotalCount
-      <$> query
-        [sql|
+  withTotalCount
+    <$> query
+      [sql|
     SELECT  lv."package_id"
           , lv."namespace"
           , lv."name"
@@ -689,59 +655,44 @@ listAllPackagesInNamespace (offset, limit) namespace =
     LIMIT ?
     ;
     |]
-        (namespace, offset, limit)
+      (namespace, offset, limit)
 
-countPackages :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es Word
-countPackages = labeled @ReadOnly @WithConnection $ do
-  (result :: Maybe (Only Int)) <-
-    queryOne_
-      [sql|
+countPackages :: (IOE :> es, ReadDB :> es) => Eff es Word
+countPackages =
+  queryCount_
+    [sql|
     SELECT DISTINCT COUNT(*)
     FROM packages
     WHERE status = 'fully-imported'
     |]
-  case result of
-    Just (Only n) -> pure $ fromIntegral n
-    Nothing -> pure 0
 
-countPackagesByName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es Word
+countPackagesByName :: (IOE :> es, ReadDB :> es) => Text -> Eff es Word
 countPackagesByName searchString =
-  do
-    (result :: Maybe (Only Int)) <-
-      queryOne
-        [sql|
+  queryCount
+    [sql|
         SELECT DISTINCT COUNT(*)
         FROM latest_versions as lv
         WHERE ? <% lv.name
       |]
-        (Only searchString)
-    case result of
-      Just (Only n) -> pure $ fromIntegral n
-      Nothing -> pure 0
+    (Only searchString)
 
-countPackagesInNamespace :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Namespace -> Eff es Word
+countPackagesInNamespace :: (IOE :> es, ReadDB :> es) => Namespace -> Eff es Word
 countPackagesInNamespace namespace =
-  do
-    (result :: Maybe (Only Int)) <-
-      queryOne
-        [sql|
+  queryCount
+    [sql|
         SELECT DISTINCT COUNT(*)
         FROM latest_versions as lv
         WHERE lv."namespace" = ?
       |]
-        (Only namespace)
-    case result of
-      Just (Only n) -> pure $ fromIntegral n
-      Nothing -> pure 0
+    (Only namespace)
 
 getTransitiveDependencies
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Log :> es)
+  :: (IOE :> es, Log :> es, ReadDB :> es)
   => ComponentId
   -> Eff es (Vector PackageDependencies)
 getTransitiveDependencies componentId = do
   results :: Vector (ComponentId, Namespace, PackageName, PGArray (PGArray Text)) <-
-    labeled @ReadOnly @WithConnection $
-      Vector.fromList <$> query sqlQuery (Only componentId)
+    Vector.fromList <$> query sqlQuery (Only componentId)
   let dependencies =
         results
           & Vector.map
@@ -816,9 +767,9 @@ WITH RECURSIVE transitive_dependencies(  dependent_id, dependent_namespace, depe
 |]
 
 getLatestPackages
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Eff es (Vector (Namespace, PackageName, Text, Version, Maybe UTCTime))
-getLatestPackages = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query sqlQuery ()
+getLatestPackages = Vector.fromList <$> query sqlQuery ()
   where
     sqlQuery =
       [sql|
@@ -837,14 +788,11 @@ getLatestPackages = labeled @ReadOnly @WithConnection $ Vector.fromList <$> quer
       |]
 
 getUploaders
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> FloraM es (Vector Text)
 getUploaders packageId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList <$> do
-      result <- query sqlQuery (Only packageId)
-      pure $ fromOnly <$> result
+  Vector.fromList . fmap fromOnly <$> query sqlQuery (Only packageId)
   where
     sqlQuery =
       [sql|
@@ -857,9 +805,9 @@ getUploaders packageId =
       |]
 
 getPackagesWithoutMaintainersInformation
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (Namespace, PackageName))
-getPackagesWithoutMaintainersInformation = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query sqlQuery ()
+getPackagesWithoutMaintainersInformation = Vector.fromList <$> query sqlQuery ()
   where
     sqlQuery =
       [sql|

--- a/src/core/Flora/Model/Package/Update.hs
+++ b/src/core/Flora/Model/Package/Update.hs
@@ -15,8 +15,6 @@ import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Database.PostgreSQL.Simple.ToRow
 import Effectful
 import Effectful.Exception qualified as E
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import RequireCallStack
 
 import Flora.DB.Exception
@@ -26,10 +24,10 @@ import Flora.Model.Package.Orphans ()
 import Flora.Model.Package.Types
 import Flora.Model.Requirement (Requirement)
 
-upsertPackage :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => Package -> Eff es ()
+upsertPackage :: (IOE :> es, RequireCallStack, WriteDB :> es) => Package -> Eff es ()
 upsertPackage package =
   E.catch
-    ( labeled @ReadWrite @WithConnection $ do
+    ( do
         upsertWith package
         case package.status of
           UnknownPackage -> pure ()
@@ -44,8 +42,8 @@ upsertPackage package =
     upsertWith entity =
       void $ execute (_insert @Package <> " ON CONFLICT DO NOTHING") entity
 
-deprecatePackages :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => Vector DeprecatedPackage -> Eff es ()
-deprecatePackages dp = labeled @ReadWrite @WithConnection $ void $ executeMany q (dp & Vector.map Only & Vector.toList)
+deprecatePackages :: (IOE :> es, RequireCallStack, WriteDB :> es) => Vector DeprecatedPackage -> Eff es ()
+deprecatePackages dp = void $ executeMany q (dp & Vector.map Only & Vector.toList)
   where
     q =
       [sql|
@@ -55,33 +53,33 @@ deprecatePackages dp = labeled @ReadWrite @WithConnection $ void $ executeMany q
       WHERE p0.name = jsonb(js) ->> 'package'
       |]
 
-deletePackage :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => (Namespace, PackageName) -> Eff es ()
-deletePackage (namespace, packageName) = labeled @ReadWrite @WithConnection $ void $ execute (_deleteWhere @Package [primaryKey @Package]) (namespace, packageName)
+deletePackage :: (IOE :> es, RequireCallStack, WriteDB :> es) => (Namespace, PackageName) -> Eff es ()
+deletePackage (namespace, packageName) = void $ execute (_deleteWhere @Package [primaryKey @Package]) (namespace, packageName)
 
-refreshDependents :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => Eff es ()
+refreshDependents :: (IOE :> es, RequireCallStack, WriteDB :> es) => Eff es ()
 refreshDependents =
-  labeled @ReadWrite @WithConnection $ void $ execute [sql| REFRESH MATERIALIZED VIEW CONCURRENTLY "dependents"|] ()
+  void $ execute [sql| REFRESH MATERIALIZED VIEW CONCURRENTLY "dependents"|] ()
 
-insertPackageComponent :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => PackageComponent -> Eff es ()
-insertPackageComponent pc = labeled @ReadWrite @WithConnection $ void $ execute (_insert @PackageComponent) pc
+insertPackageComponent :: (IOE :> es, RequireCallStack, WriteDB :> es) => PackageComponent -> Eff es ()
+insertPackageComponent pc = void $ execute (_insert @PackageComponent) pc
 
-upsertPackageComponent :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => PackageComponent -> Eff es ()
+upsertPackageComponent :: (IOE :> es, RequireCallStack, WriteDB :> es) => PackageComponent -> Eff es ()
 upsertPackageComponent packageComponent =
-  labeled @ReadWrite @WithConnection $ upsert @PackageComponent packageComponent (fields @PackageComponent)
+  upsert @PackageComponent packageComponent (fields @PackageComponent)
 
-upsertPackageComponents :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => [PackageComponent] -> Eff es ()
+upsertPackageComponents :: (IOE :> es, RequireCallStack, WriteDB :> es) => [PackageComponent] -> Eff es ()
 upsertPackageComponents packageComponents =
-  labeled @ReadWrite @WithConnection $ void $ executeMany (_insert @PackageComponent <> " ON CONFLICT DO NOTHING") packageComponents
+  void $ executeMany (_insert @PackageComponent <> " ON CONFLICT DO NOTHING") packageComponents
 
-bulkInsertPackageComponents :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => [PackageComponent] -> Eff es ()
-bulkInsertPackageComponents pcs = labeled @ReadWrite @WithConnection $ void $ executeMany (_insert @PackageComponent) pcs
+bulkInsertPackageComponents :: (IOE :> es, RequireCallStack, WriteDB :> es) => [PackageComponent] -> Eff es ()
+bulkInsertPackageComponents pcs = void $ executeMany (_insert @PackageComponent) pcs
 
-insertRequirement :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => Requirement -> Eff es ()
-insertRequirement req = labeled @ReadWrite @WithConnection $ void $ execute (_insert @Requirement) req
+insertRequirement :: (IOE :> es, RequireCallStack, WriteDB :> es) => Requirement -> Eff es ()
+insertRequirement req = void $ execute (_insert @Requirement) req
 
-upsertRequirement :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => Requirement -> Eff es ()
-upsertRequirement req = labeled @ReadWrite @WithConnection $ upsert @Requirement req [[field| components |], [field| requirement |]]
+upsertRequirement :: (IOE :> es, RequireCallStack, WriteDB :> es) => Requirement -> Eff es ()
+upsertRequirement req = upsert @Requirement req [[field| components |], [field| requirement |]]
 
-bulkInsertRequirements :: (IOE :> es, Labeled ReadWrite WithConnection :> es, RequireCallStack) => [Requirement] -> Eff es ()
+bulkInsertRequirements :: (IOE :> es, RequireCallStack, WriteDB :> es) => [Requirement] -> Eff es ()
 bulkInsertRequirements requirements =
-  labeled @ReadWrite @WithConnection $ unless (List.null requirements) $ void (executeMany (_insert @Requirement) requirements)
+  unless (List.null requirements) $ void (executeMany (_insert @Requirement) requirements)

--- a/src/core/Flora/Model/PackageGroup/Query.hs
+++ b/src/core/Flora/Model/PackageGroup/Query.hs
@@ -13,18 +13,16 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Entity.Types
 import Database.PostgreSQL.Simple (Only (..))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.PackageGroup.Types
 
-getPackageGroupById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageGroupId -> Eff es (Maybe PackageGroup)
-getPackageGroupById groupId = labeled @_ @WithConnection $ queryOne (_selectWhere @PackageGroup [[field| package_group_id |]]) (Only groupId)
+getPackageGroupById :: (IOE :> es, ReadDB :> es) => PackageGroupId -> Eff es (Maybe PackageGroup)
+getPackageGroupById groupId = queryOne (_selectWhere @PackageGroup [[field| package_group_id |]]) (Only groupId)
 
-getPackageGroupByPackageGroupName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageGroupName -> Eff es (Maybe PackageGroup)
-getPackageGroupByPackageGroupName groupName = labeled @_ @WithConnection $ queryOne (_selectWhere @PackageGroup [[field| group_name |]]) (Only groupName)
+getPackageGroupByPackageGroupName :: (IOE :> es, ReadDB :> es) => PackageGroupName -> Eff es (Maybe PackageGroup)
+getPackageGroupByPackageGroupName groupName = queryOne (_selectWhere @PackageGroup [[field| group_name |]]) (Only groupName)
 
-listPackageGroups :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector PackageGroup)
+listPackageGroups :: (IOE :> es, ReadDB :> es) => Eff es (Vector PackageGroup)
 listPackageGroups =
-  labeled @_ @WithConnection $ Vector.fromList <$> query_ (_select @PackageGroup <> _orderByMany [([field| group_name |], ASC)])
+  Vector.fromList <$> query_ (_select @PackageGroup <> _orderByMany [([field| group_name |], ASC)])

--- a/src/core/Flora/Model/PackageGroup/Update.hs
+++ b/src/core/Flora/Model/PackageGroup/Update.hs
@@ -7,16 +7,14 @@ import Control.Monad (void)
 import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Simple.Types
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.PackageGroup.Types
 
-insertPackageGroup :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => PackageGroup -> Eff es ()
+insertPackageGroup :: (IOE :> es, WriteDB :> es) => PackageGroup -> Eff es ()
 insertPackageGroup packageGroup = do
-  void $ labeled @ReadWrite @WithConnection $ execute (_insert @PackageGroup) packageGroup
+  void $ execute (_insert @PackageGroup) packageGroup
 
-deletePackageGroup :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => PackageGroupId -> Eff es ()
+deletePackageGroup :: (IOE :> es, WriteDB :> es) => PackageGroupId -> Eff es ()
 deletePackageGroup packageGroupId = do
-  void $ labeled @ReadWrite @WithConnection $ execute (_delete @PackageGroup) (Only packageGroupId)
+  void $ execute (_delete @PackageGroup) (Only packageGroupId)

--- a/src/core/Flora/Model/PackageGroupPackage/Query.hs
+++ b/src/core/Flora/Model/PackageGroupPackage/Query.hs
@@ -13,20 +13,18 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Package.Types
 import Flora.Model.PackageGroup.Types
 import Flora.Model.PackageGroupPackage.Types
 
-getPackageGroupPackage :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageGroupPackageId -> Eff es (Maybe PackageGroupPackage)
-getPackageGroupPackage packageGroupPackageId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @PackageGroupPackage [primaryKey @PackageGroupPackage]) (Only packageGroupPackageId)
+getPackageGroupPackage :: (IOE :> es, ReadDB :> es) => PackageGroupPackageId -> Eff es (Maybe PackageGroupPackage)
+getPackageGroupPackage packageGroupPackageId = queryOne (_selectWhere @PackageGroupPackage [primaryKey @PackageGroupPackage]) (Only packageGroupPackageId)
 
-getPackageGroupsForPackage :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> Eff es (Vector PackageGroupName)
+getPackageGroupsForPackage :: (IOE :> es, ReadDB :> es) => PackageId -> Eff es (Vector PackageGroupName)
 getPackageGroupsForPackage packageId = do
-  results :: Vector (Only PackageGroupName) <- labeled @ReadOnly @WithConnection $ Vector.fromList <$> query q (Only packageId)
+  results :: Vector (Only PackageGroupName) <- Vector.fromList <$> query q (Only packageId)
   pure $ fmap fromOnly results
   where
     q =
@@ -37,8 +35,8 @@ getPackageGroupsForPackage packageId = do
         WHERE p0.package_id = ?
       |]
 
-listPackageGroupPackages :: (IOE :> es, Labeled w0 WithConnection :> es) => PackageGroupId -> Eff es (Vector PackageInfo)
-listPackageGroupPackages groupId = labeled @_ @WithConnection $ Vector.fromList <$> query q (Only groupId)
+listPackageGroupPackages :: (IOE :> es, ReadDB :> es) => PackageGroupId -> Eff es (Vector PackageInfo)
+listPackageGroupPackages groupId = Vector.fromList <$> query q (Only groupId)
   where
     q =
       [sql|

--- a/src/core/Flora/Model/PackageGroupPackage/Update.hs
+++ b/src/core/Flora/Model/PackageGroupPackage/Update.hs
@@ -10,18 +10,16 @@ import Control.Monad (void)
 import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Entity.Internal.QQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Package.Types (PackageId (..))
 import Flora.Model.PackageGroup.Types (PackageGroupId (..))
 import Flora.Model.PackageGroupPackage.Types
 
-addPackageToPackageGroup :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => PackageGroupPackage -> Eff es ()
+addPackageToPackageGroup :: (IOE :> es, WriteDB :> es) => PackageGroupPackage -> Eff es ()
 addPackageToPackageGroup packageGroupPackage =
-  void $ labeled @ReadWrite @WithConnection $ execute (_insert @PackageGroupPackage) packageGroupPackage
+  void $ execute (_insert @PackageGroupPackage) packageGroupPackage
 
-removePackageFromPackageGroup :: (IOE :> es, Labeled w0 WithConnection :> es) => PackageId -> PackageGroupId -> Eff es ()
+removePackageFromPackageGroup :: (IOE :> es, WriteDB :> es) => PackageId -> PackageGroupId -> Eff es ()
 removePackageFromPackageGroup pId pgId =
-  void $ labeled @_ @WithConnection $ execute (_deleteWhere @PackageGroupPackage [[field|  package_id |], [field|  package_group_id |]]) (pId, pgId)
+  void $ execute (_deleteWhere @PackageGroupPackage [[field|  package_id |], [field|  package_group_id |]]) (pId, pgId)

--- a/src/core/Flora/Model/PackageIndex/Guard.hs
+++ b/src/core/Flora/Model/PackageIndex/Guard.hs
@@ -2,8 +2,6 @@ module Flora.Model.PackageIndex.Guard where
 
 import Data.Text (Text)
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Effectful.Tracing (Tracer)
 import Effectful.Tracing qualified as Trace
 
@@ -12,7 +10,7 @@ import Flora.Model.PackageIndex.Query qualified as Query
 import Flora.Model.PackageIndex.Types
 
 guardThatPackageIndexExists
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Tracer :> es)
+  :: (IOE :> es, ReadDB :> es, Tracer :> es)
   => Text
   -> Eff es PackageIndex
   -- ^ Action to run if the package does not exist

--- a/src/core/Flora/Model/PackageIndex/Query.hs
+++ b/src/core/Flora/Model/PackageIndex/Query.hs
@@ -11,37 +11,32 @@ import Database.PostgreSQL.Entity.Types
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.PackageIndex.Types
 
 getPackageIndexById
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageIndexId
   -> Eff es (Maybe PackageIndex)
 getPackageIndexById packageIndexId =
-  labeled @ReadOnly @WithConnection $
-    queryOne (_selectWhere @PackageIndex [[field| package_index_id |]]) (Only packageIndexId)
+  queryOne (_selectWhere @PackageIndex [[field| package_index_id |]]) (Only packageIndexId)
 
-getPackageIndexByName :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Maybe PackageIndex)
+getPackageIndexByName :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Maybe PackageIndex)
 getPackageIndexByName repository =
-  labeled @ReadOnly @WithConnection $
-    queryOne (_selectWhere @PackageIndex [[field| repository |]]) (Only repository)
+  queryOne (_selectWhere @PackageIndex [[field| repository |]]) (Only repository)
 
-listPackageIndexes :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector PackageIndex)
+listPackageIndexes :: (IOE :> es, ReadDB :> es) => Eff es (Vector PackageIndex)
 listPackageIndexes =
-  labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ (_select @PackageIndex <> _orderByMany [([field| repository |], ASC)])
+  Vector.fromList <$> query_ (_select @PackageIndex <> _orderByMany [([field| repository |], ASC)])
 
 -- | Returns an ordered list of index dependencies, which must be
 -- traversed **in order** to determine the provenance of a dependency.
-getIndexDependencies :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageIndexId -> Eff es (Vector Text)
+getIndexDependencies :: (IOE :> es, ReadDB :> es) => PackageIndexId -> Eff es (Vector Text)
 getIndexDependencies packageIndexId = do
   result' <-
-    labeled @ReadOnly @WithConnection $
-      Vector.fromList
-        <$> query q (Only packageIndexId)
+    Vector.fromList
+      <$> query q (Only packageIndexId)
   pure $ fromOnly <$> result'
   where
     q =

--- a/src/core/Flora/Model/PackageIndex/Update.hs
+++ b/src/core/Flora/Model/PackageIndex/Update.hs
@@ -17,8 +17,6 @@ import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ
 import Database.PostgreSQL.Simple.ToRow
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Heptapod qualified
 
 import Data.Positive
@@ -29,31 +27,30 @@ import Flora.Model.PackageIndex.Types
   , mkPackageIndex
   )
 
-updatePackageIndexByName :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Text -> Maybe UTCTime -> Eff es ()
+updatePackageIndexByName :: (IOE :> es, WriteDB :> es) => Text -> Maybe UTCTime -> Eff es ()
 updatePackageIndexByName repositoryName newTimestamp = do
   void $
-    labeled @ReadWrite @WithConnection $
-      execute
-        ( _updateFieldsBy @PackageIndex
-            [[field| timestamp |]]
-            [field| repository |]
-        )
-        ( toRow (Only newTimestamp)
-            ++ toRow (Only repositoryName)
-        )
+    execute
+      ( _updateFieldsBy @PackageIndex
+          [[field| timestamp |]]
+          [field| repository |]
+      )
+      ( toRow (Only newTimestamp)
+          ++ toRow (Only repositoryName)
+      )
 
-createPackageIndex :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Text -> Text -> Text -> Maybe UTCTime -> Eff es ()
+createPackageIndex :: (IOE :> es, WriteDB :> es) => Text -> Text -> Text -> Maybe UTCTime -> Eff es ()
 createPackageIndex repositoryName url description timestamp = do
   packageIndex <- mkPackageIndex repositoryName url description timestamp
-  void $ labeled @_ @WithConnection $ execute (_insert @PackageIndex) packageIndex
+  void $ execute (_insert @PackageIndex) packageIndex
 
-upsertPackageIndex :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Text -> Text -> Text -> Maybe UTCTime -> Eff es ()
+upsertPackageIndex :: (IOE :> es, WriteDB :> es) => Text -> Text -> Text -> Maybe UTCTime -> Eff es ()
 upsertPackageIndex repositoryName url description timestamp = do
   packageIndex <- mkPackageIndex repositoryName url description timestamp
-  labeled @ReadWrite @WithConnection $ void $ execute (_insert @PackageIndex <> " ON CONFLICT DO NOTHING") packageIndex
+  void $ execute (_insert @PackageIndex <> " ON CONFLICT DO NOTHING") packageIndex
 
 addDependency
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => PackageIndexId
   -- ^ Index
   -> PackageIndexId
@@ -64,8 +61,7 @@ addDependency
 addDependency indexId dependencyId priority = do
   indexDependencyId <- liftIO Heptapod.generate
   void $
-    labeled @ReadWrite @WithConnection $
-      execute q (indexDependencyId, indexId, dependencyId, priority)
+    execute q (indexDependencyId, indexId, dependencyId, priority)
   where
     q =
       [sql|

--- a/src/core/Flora/Model/PackageMaintainer/Query.hs
+++ b/src/core/Flora/Model/PackageMaintainer/Query.hs
@@ -16,8 +16,6 @@ import Database.PostgreSQL.Entity.Internal.QQ (field)
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Package.Types
@@ -26,19 +24,19 @@ import Flora.Model.PackageMaintainer.Types
 import Flora.Monad
 
 getPackageMaintainerById
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageMaintainerId
   -> Eff es (Maybe PackageMaintainer)
 getPackageMaintainerById packageMaintainerId = do
-  labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @PackageMaintainer [primaryKey @PackageMaintainer]) (Only packageMaintainerId)
+  queryOne (_selectWhere @PackageMaintainer [primaryKey @PackageMaintainer]) (Only packageMaintainerId)
 
 getPackageMaintainerByUsernameAndIndex
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Text
   -> PackageIndexId
   -> Eff es (Maybe PackageMaintainer)
 getPackageMaintainerByUsernameAndIndex username packageIndexId = do
-  labeled @ReadOnly @WithConnection $ queryOne q (username, packageIndexId)
+  queryOne q (username, packageIndexId)
   where
     q =
       _selectWhere @PackageMaintainer
@@ -47,17 +45,17 @@ getPackageMaintainerByUsernameAndIndex username packageIndexId = do
         ]
 
 getPackageMaintainers
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> Eff es (Vector PackageMaintainer)
 getPackageMaintainers packageId =
-  labeled @ReadOnly @WithConnection $ Vector.fromList <$> query (_selectWhere @PackageMaintainer [[field| package_id |]]) (Only packageId)
+  Vector.fromList <$> query (_selectWhere @PackageMaintainer [[field| package_id |]]) (Only packageId)
 
 getActiveMaintainers
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> FloraM es (Vector Text)
-getActiveMaintainers packageId = labeled @ReadOnly @WithConnection $ do
+getActiveMaintainers packageId = do
   result <- Vector.fromList <$> query sqlQuery (Only packageId)
   pure $ fromOnly <$> result
   where

--- a/src/core/Flora/Model/PackageMaintainer/Update.hs
+++ b/src/core/Flora/Model/PackageMaintainer/Update.hs
@@ -6,17 +6,14 @@ import Control.Monad
 import Data.List (List)
 import Database.PostgreSQL.Entity
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.PackageMaintainer.Types
 
 insertPackageMaintainers
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => List PackageMaintainer
   -> Eff es ()
 insertPackageMaintainers packageMaintainers =
-  labeled @ReadWrite @WithConnection $
-    void $
-      executeMany (_insert @PackageMaintainer) packageMaintainers
+  void $
+    executeMany (_insert @PackageMaintainer) packageMaintainers

--- a/src/core/Flora/Model/PackageUploader/Guard.hs
+++ b/src/core/Flora/Model/PackageUploader/Guard.hs
@@ -2,8 +2,6 @@ module Flora.Model.PackageUploader.Guard where
 
 import Data.Text
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Effectful.Tracing (Tracer)
 import Effectful.Tracing qualified as Trace
 
@@ -13,7 +11,7 @@ import Flora.Model.PackageUploader.Query qualified as Query
 import Flora.Model.PackageUploader.Types
 
 guardThatPackageUploaderExists
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Tracer :> es)
+  :: (IOE :> es, ReadDB :> es, Tracer :> es)
   => Text
   -> PackageIndexId
   -> Eff es PackageUploader

--- a/src/core/Flora/Model/PackageUploader/Query.hs
+++ b/src/core/Flora/Model/PackageUploader/Query.hs
@@ -15,8 +15,6 @@ import Database.PostgreSQL.Entity.Internal.QQ (field)
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.Package.Types
@@ -26,11 +24,11 @@ import Flora.Model.PackageUploader.Types
 import Flora.Monad
 
 getPackageUploaderById
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageUploaderId
   -> Eff es (Maybe PackageUploader)
 getPackageUploaderById packageUploaderId = do
-  mDao :: Maybe PackageUploaderDAO <- labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @PackageUploaderDAO [primaryKey @PackageUploaderDAO]) (Only packageUploaderId)
+  mDao :: Maybe PackageUploaderDAO <- queryOne (_selectWhere @PackageUploaderDAO [primaryKey @PackageUploaderDAO]) (Only packageUploaderId)
   case mDao of
     Nothing -> pure Nothing
     Just dao -> do
@@ -48,12 +46,12 @@ getPackageUploaderById packageUploaderId = do
                 }
 
 getPackageUploaderByUsernameAndIndex
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Text
   -> PackageIndexId
   -> Eff es (Maybe PackageUploader)
 getPackageUploaderByUsernameAndIndex username packageIndexId = do
-  mDao :: Maybe PackageUploaderDAO <- labeled @ReadOnly @WithConnection $ queryOne q (username, packageIndexId)
+  mDao :: Maybe PackageUploaderDAO <- queryOne q (username, packageIndexId)
   case mDao of
     Nothing -> pure Nothing
     Just dao -> do
@@ -77,13 +75,12 @@ getPackageUploaderByUsernameAndIndex username packageIndexId = do
         ]
 
 getPackageUploaders
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> FloraM es (Vector PackageUploaderDAO)
 getPackageUploaders packageId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query sqlQuery (Only packageId)
+  Vector.fromList
+    <$> query sqlQuery (Only packageId)
   where
     sqlQuery =
       [sql|

--- a/src/core/Flora/Model/PackageUploader/Update.hs
+++ b/src/core/Flora/Model/PackageUploader/Update.hs
@@ -11,8 +11,6 @@ import Data.Text (Text)
 import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.PackageIndex.Types
@@ -20,19 +18,18 @@ import Flora.Model.PackageUploader.Query qualified as Query
 import Flora.Model.PackageUploader.Types
 
 insertPackageUploader
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => PackageUploaderDAO
   -> Eff es ()
 insertPackageUploader packageUploader =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute (_insert @PackageUploaderDAO) packageUploader
+  void $
+    execute (_insert @PackageUploaderDAO) packageUploader
 
 insertMaybeExistingPackageUploader
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => PackageUploaderDAO
   -> Eff es ()
-insertMaybeExistingPackageUploader packageUploaderDAO = labeled @ReadWrite @WithConnection $ do
+insertMaybeExistingPackageUploader packageUploaderDAO = do
   void $ execute sqlQuery packageUploaderDAO
   where
     sqlQuery =
@@ -43,7 +40,7 @@ insertMaybeExistingPackageUploader packageUploaderDAO = labeled @ReadWrite @With
       |]
 
 getOrInsertPackageUploader
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es, WriteDB :> es)
   => Text
   -> PackageIndexId
   -> Eff es PackageUploaderId

--- a/src/core/Flora/Model/PersistentSession.hs
+++ b/src/core/Flora/Model/PersistentSession.hs
@@ -20,17 +20,12 @@ import Database.PostgreSQL.Simple.ToField
 import Database.PostgreSQL.Simple.ToRow
 import Database.PostgreSQL.Simple.Types
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
-import Effectful.Reader.Static (Reader)
-import Effectful.Reader.Static qualified as Reader
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
 import Env.Generic
 import Web.HttpApiData
 
 import Flora.Database
-import Flora.Environment.Env
 import Flora.Model.User (UserId)
 import Flora.Monad
 
@@ -71,24 +66,23 @@ newPersistentSession userId persistentSessionId = do
   pure $ PersistentSession{userId, persistentSessionId, createdAt, sessionData}
 
 persistSession
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Reader FloraEnv :> es, Time :> es)
+  :: (IOE :> es, Time :> es, WriteDB :> es)
   => PersistentSessionId
   -> UserId
   -> FloraM es PersistentSessionId
 persistSession persistentSessionId userId = do
-  FloraEnv{pool} <- Reader.ask
   persistentSession <- newPersistentSession userId persistentSessionId
-  withReadWritePool pool $ insertSession persistentSession
+  insertSession persistentSession
   pure persistentSession.persistentSessionId
 
-insertSession :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => PersistentSession -> FloraM es ()
-insertSession = void . labeled @ReadWrite @WithConnection . execute (_insert @PersistentSession)
+insertSession :: (IOE :> es, WriteDB :> es) => PersistentSession -> FloraM es ()
+insertSession = void . execute (_insert @PersistentSession)
 
-deleteSession :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => PersistentSessionId -> FloraM es ()
-deleteSession sessionId = void . labeled @ReadWrite @WithConnection $ execute (_delete @PersistentSession) (Only sessionId)
+deleteSession :: (IOE :> es, WriteDB :> es) => PersistentSessionId -> FloraM es ()
+deleteSession sessionId = void $ execute (_delete @PersistentSession) (Only sessionId)
 
-getPersistentSession :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PersistentSessionId -> FloraM es (Maybe PersistentSession)
-getPersistentSession sessionId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @PersistentSession [primaryKey @PersistentSession]) (Only sessionId)
+getPersistentSession :: (IOE :> es, ReadDB :> es) => PersistentSessionId -> FloraM es (Maybe PersistentSession)
+getPersistentSession sessionId = queryOne (_selectWhere @PersistentSession [primaryKey @PersistentSession]) (Only sessionId)
 
 lookup :: Text -> SessionData -> Maybe Text
 lookup key (SessionData sdMap) = Map.lookup key sdMap

--- a/src/core/Flora/Model/Release/Guard.hs
+++ b/src/core/Flora/Model/Release/Guard.hs
@@ -2,8 +2,6 @@ module Flora.Model.Release.Guard where
 
 import Distribution.Types.Version (Version)
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Effectful.Tracing (Tracer)
 import Effectful.Tracing qualified as Trace
 
@@ -14,7 +12,7 @@ import Flora.Model.Release.Types
 import Flora.Monad
 
 guardThatReleaseExists
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Tracer :> es)
+  :: (IOE :> es, ReadDB :> es, Tracer :> es)
   => PackageId
   -> Version
   -> (Version -> FloraM es Release)

--- a/src/core/Flora/Model/Release/Query.hs
+++ b/src/core/Flora/Model/Release/Query.hs
@@ -37,8 +37,6 @@ import Database.PostgreSQL.Simple.SqlQQ
 import Database.PostgreSQL.Simple.Types (In (..), Only (..), Query)
 import Distribution.Version (Version)
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Distribution.Orphans.Version ()
 import Flora.Database
@@ -60,53 +58,49 @@ packageReleasesQuery =
   _selectWhere @Release [[field| package_id |]]
     <> " ORDER BY releases.version DESC "
 
-getReleases :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> FloraM es (Vector Release)
+getReleases :: (IOE :> es, ReadDB :> es) => PackageId -> FloraM es (Vector Release)
 getReleases pid =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query (packageReleasesQuery <> " LIMIT 6") (Only pid)
+  Vector.fromList
+    <$> query (packageReleasesQuery <> " LIMIT 6") (Only pid)
 
-getLatestPackageRelease :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> FloraM es (Maybe Release)
+getLatestPackageRelease :: (IOE :> es, ReadDB :> es) => PackageId -> FloraM es (Maybe Release)
 getLatestPackageRelease pid =
-  labeled @ReadOnly @WithConnection $ do
-    queryOne getLatestPackageReleaseQuery (Only pid)
+  queryOne getLatestPackageReleaseQuery (Only pid)
 
-getLatestReleaseTime :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Maybe Text -> FloraM es (Maybe UTCTime)
+getLatestReleaseTime :: (IOE :> es, ReadDB :> es) => Maybe Text -> FloraM es (Maybe UTCTime)
 getLatestReleaseTime repo =
-  labeled @ReadOnly @WithConnection $ fmap fromOnly <$> maybe (queryOne_ q') (queryOne q . Only) repo
+  fmap fromOnly <$> maybe (queryOne_ q') (queryOne q . Only) repo
   where
     q = [sql| select max(r0.uploaded_at) from releases as r0 where r0.repository = ? |]
     q' = [sql| select max(uploaded_at) from releases |]
 
-getReleaseTarballRootHash :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> FloraM es (Maybe Sha256Sum)
-getReleaseTarballRootHash releaseId = labeled @ReadOnly @WithConnection $ do
+getReleaseTarballRootHash :: (IOE :> es, ReadDB :> es) => ReleaseId -> FloraM es (Maybe Sha256Sum)
+getReleaseTarballRootHash releaseId = do
   mRelease :: Maybe Release <- queryOne (_selectWhere @Release [[field| release_id |]]) (Only releaseId)
   case mRelease of
     Just release -> pure release.tarballRootHash
     Nothing -> error $ "Internal error: searched for releaseId that doesn't exist: " <> show releaseId
 
-getReleaseTarballArchive :: (BlobStoreAPI :> es, IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> FloraM es (Maybe LazyByteString)
-getReleaseTarballArchive releaseId = labeled @ReadOnly @WithConnection $ do
+getReleaseTarballArchive :: (BlobStoreAPI :> es, IOE :> es, ReadDB :> es) => ReleaseId -> FloraM es (Maybe LazyByteString)
+getReleaseTarballArchive releaseId = do
   mRelease :: Maybe Release <- queryOne (_selectWhere @Release [[field| release_id |]]) (Only releaseId)
   case mRelease of
     Nothing -> error $ "Internal error: searched for releaseId that doesn't exist: " <> show releaseId
     Just release -> do
       fmap fromStrict . join <$> traverse get release.tarballArchiveHash
 
-getAllReleases :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> FloraM es (Vector Release)
+getAllReleases :: (IOE :> es, ReadDB :> es) => PackageId -> FloraM es (Vector Release)
 getAllReleases pid =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query packageReleasesQuery (Only pid)
+  Vector.fromList
+    <$> query packageReleasesQuery (Only pid)
 
 getVersionFromManyReleaseIds
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => Vector ReleaseId
   -> FloraM es (Vector (ReleaseId, Version))
 getVersionFromManyReleaseIds releaseIds = do
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query q (Only (In (Vector.toList releaseIds)))
+  Vector.fromList
+    <$> query q (Only (In (Vector.toList releaseIds)))
   where
     q =
       [sql|
@@ -116,12 +110,11 @@ getVersionFromManyReleaseIds releaseIds = do
       |]
 
 getHackagePackageReleasesWithoutReadme
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (ReleaseId, Version, PackageName))
 getHackagePackageReleasesWithoutReadme =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query querySpec ()
+  Vector.fromList
+    <$> query querySpec ()
   where
     querySpec :: Query
     querySpec =
@@ -136,12 +129,11 @@ getHackagePackageReleasesWithoutReadme =
       |]
 
 getHackagePackageReleasesWithoutUploadInformation
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (ReleaseId, Version, PackageName))
 getHackagePackageReleasesWithoutUploadInformation =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query querySpec ()
+  Vector.fromList
+    <$> query querySpec ()
   where
     querySpec :: Query
     querySpec =
@@ -156,12 +148,11 @@ getHackagePackageReleasesWithoutUploadInformation =
       |]
 
 getHackagePackageReleasesWithoutChangelog
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (ReleaseId, Version, PackageName))
 getHackagePackageReleasesWithoutChangelog =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query querySpec ()
+  Vector.fromList
+    <$> query querySpec ()
   where
     querySpec :: Query
     querySpec =
@@ -176,12 +167,11 @@ getHackagePackageReleasesWithoutChangelog =
       |]
 
 getHackagePackageReleasesWithoutTarball
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (ReleaseId, Version, PackageName))
 getHackagePackageReleasesWithoutTarball =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query querySpec ()
+  Vector.fromList
+    <$> query querySpec ()
   where
     querySpec =
       [sql|
@@ -194,10 +184,10 @@ getHackagePackageReleasesWithoutTarball =
       |]
 
 getHackagePackagesWithoutReleaseDeprecationInformation
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (PackageName, Vector ReleaseId))
 getHackagePackagesWithoutReleaseDeprecationInformation =
-  labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ q
+  Vector.fromList <$> query_ q
   where
     q =
       [sql|
@@ -211,33 +201,27 @@ getHackagePackagesWithoutReleaseDeprecationInformation =
         |]
 
 getReleaseById
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => ReleaseId
   -> FloraM es (Maybe Release)
 getReleaseById releaseId =
-  labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @Release [primaryKey @Release]) (Only releaseId)
+  queryOne (_selectWhere @Release [primaryKey @Release]) (Only releaseId)
 
 getReleaseByVersion
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> Version
   -> FloraM es (Maybe Release)
 getReleaseByVersion packageId version =
-  labeled @ReadOnly @WithConnection $
-    queryOne
-      ( _selectWhere
-          @Release
-          [[field| package_id |], [field| version |]]
-      )
-      (packageId, version)
+  queryOne
+    ( _selectWhere
+        @Release
+        [[field| package_id |], [field| version |]]
+    )
+    (packageId, version)
 
-getNumberOfReleases :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => PackageId -> FloraM es Word
-getNumberOfReleases pid =
-  labeled @ReadOnly @WithConnection $ do
-    (result :: Maybe (Only Int)) <- queryOne numberOfReleasesQuery (Only pid)
-    case result of
-      Just (Only n) -> pure $ fromIntegral n
-      Nothing -> pure 0
+getNumberOfReleases :: (IOE :> es, ReadDB :> es) => PackageId -> FloraM es Word
+getNumberOfReleases pid = queryCount numberOfReleasesQuery (Only pid)
 
 numberOfReleasesQuery :: Query
 numberOfReleasesQuery =
@@ -247,14 +231,13 @@ numberOfReleasesQuery =
   WHERE rel."package_id" = ?
   |]
 
-getReleaseComponents :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> FloraM es (Vector PackageComponent)
+getReleaseComponents :: (IOE :> es, ReadDB :> es) => ReleaseId -> FloraM es (Vector PackageComponent)
 getReleaseComponents releaseId =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query (_selectWhere @PackageComponent [[field| release_id |]]) (Only releaseId)
+  Vector.fromList
+    <$> query (_selectWhere @PackageComponent [[field| release_id |]]) (Only releaseId)
 
-getReleasePackageIndex :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => ReleaseId -> FloraM es (Maybe PackageIndexId)
-getReleasePackageIndex releaseId = labeled @ReadOnly @WithConnection $ do
+getReleasePackageIndex :: (IOE :> es, ReadDB :> es) => ReleaseId -> FloraM es (Maybe PackageIndexId)
+getReleasePackageIndex releaseId = do
   result :: Maybe (Only PackageIndexId) <- queryOne q (Only releaseId)
   pure $ fromOnly <$> result
   where
@@ -267,12 +250,11 @@ getReleasePackageIndex releaseId = labeled @ReadOnly @WithConnection $ do
       |]
 
 getLatestReleases
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => FloraM es (Vector (Namespace, PackageName, Text, Version, Maybe UTCTime))
 getLatestReleases =
-  labeled @ReadOnly @WithConnection $
-    Vector.fromList
-      <$> query sqlQuery ()
+  Vector.fromList
+    <$> query sqlQuery ()
   where
     sqlQuery =
       [sql|
@@ -283,11 +265,11 @@ getLatestReleases =
       |]
 
 getLatestPackageReleaseVersion
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es)
+  :: (IOE :> es, ReadDB :> es)
   => PackageId
   -> FloraM es (Maybe Version)
 getLatestPackageReleaseVersion packageId = do
-  result :: (Maybe (Only Version)) <- labeled @ReadOnly @WithConnection $ queryOne sqlQuery (Only packageId)
+  result :: (Maybe (Only Version)) <- queryOne sqlQuery (Only packageId)
   pure $ fromOnly <$> result
   where
     sqlQuery =

--- a/src/core/Flora/Model/Release/Update.hs
+++ b/src/core/Flora/Model/Release/Update.hs
@@ -37,9 +37,7 @@ import Distribution.Types.Version (Version)
 import Effectful
 import Effectful.Error.Static (Error)
 import Effectful.Error.Static qualified as Error
-import Effectful.Labeled
 import Effectful.Log (Log)
-import Effectful.PostgreSQL
 import Effectful.Reader.Static (Reader)
 import Effectful.Reader.Static qualified as Reader
 import Effectful.Time (Time)
@@ -60,11 +58,11 @@ import Flora.Model.Release.Query qualified as Query
 import Flora.Model.Release.Types
 import Flora.Monad
 
-insertRelease :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Release -> FloraM es ()
-insertRelease r = labeled @ReadWrite @WithConnection $ void $ execute (_insert @Release) r
+insertRelease :: (IOE :> es, WriteDB :> es) => Release -> FloraM es ()
+insertRelease r = void $ execute (_insert @Release) r
 
 upsertRelease
-  :: (IOE :> es, Labeled ReadOnly WithConnection :> es, Labeled ReadWrite WithConnection :> es, Log :> es, Reader FloraEnv :> es, Time :> es)
+  :: (IOE :> es, Log :> es, ReadDB :> es, Reader FloraEnv :> es, Time :> es, WriteDB :> es)
   => Package -> Release -> FloraM es ()
 upsertRelease package newRelease = do
   mReleaseFromDB <- Query.getReleaseById newRelease.releaseId
@@ -90,117 +88,108 @@ upsertRelease package newRelease = do
       entry <- Types.newReleaseEntry instanceInfo package newRelease.version
       Update.insertFeedEntry entry
 
-refreshLatestVersions :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => FloraM es ()
-refreshLatestVersions = labeled @ReadWrite @WithConnection $ void $ execute [sql| REFRESH MATERIALIZED VIEW CONCURRENTLY "latest_versions" |] ()
+refreshLatestVersions :: (IOE :> es, WriteDB :> es) => FloraM es ()
+refreshLatestVersions = void $ execute [sql| REFRESH MATERIALIZED VIEW CONCURRENTLY "latest_versions" |] ()
 
-updateReadme :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => ReleaseId -> Maybe TextHtml -> ImportStatus -> FloraM es ()
+updateReadme :: (IOE :> es, WriteDB :> es) => ReleaseId -> Maybe TextHtml -> ImportStatus -> FloraM es ()
 updateReadme releaseId readmeBody status =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [ [field| readme |]
-            , [field| readme_status |]
-            ]
-            [field| release_id |]
-        )
-        (toRow (readmeBody, status) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [ [field| readme |]
+          , [field| readme_status |]
+          ]
+          [field| release_id |]
+      )
+      (toRow (readmeBody, status) ++ toRow (Only releaseId))
 
-updateUploadTime :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => ReleaseId -> UTCTime -> FloraM es ()
+updateUploadTime :: (IOE :> es, WriteDB :> es) => ReleaseId -> UTCTime -> FloraM es ()
 updateUploadTime releaseId timestamp =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| uploaded_at |]]
-            [field| release_id |]
-        )
-        (toRow (Only (Just timestamp)) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| uploaded_at |]]
+          [field| release_id |]
+      )
+      (toRow (Only (Just timestamp)) ++ toRow (Only releaseId))
 
-updateRevisionTime :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => ReleaseId -> UTCTime -> FloraM es ()
+updateRevisionTime :: (IOE :> es, WriteDB :> es) => ReleaseId -> UTCTime -> FloraM es ()
 updateRevisionTime releaseId timestamp =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| revised_at |]]
-            [field| release_id |]
-        )
-        (toRow (Only (Just timestamp)) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| revised_at |]]
+          [field| release_id |]
+      )
+      (toRow (Only (Just timestamp)) ++ toRow (Only releaseId))
 
-updateChangelog :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => ReleaseId -> Maybe TextHtml -> ImportStatus -> FloraM es ()
+updateChangelog :: (IOE :> es, WriteDB :> es) => ReleaseId -> Maybe TextHtml -> ImportStatus -> FloraM es ()
 updateChangelog releaseId changelogBody status =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [ [field| changelog |]
-            , [field| changelog_status |]
-            ]
-            [field| release_id |]
-        )
-        (toRow (changelogBody, status) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [ [field| changelog |]
+          , [field| changelog_status |]
+          ]
+          [field| release_id |]
+      )
+      (toRow (changelogBody, status) ++ toRow (Only releaseId))
 
-updateTarballRootHash :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => ReleaseId -> Sha256Sum -> FloraM es ()
+updateTarballRootHash :: (IOE :> es, WriteDB :> es) => ReleaseId -> Sha256Sum -> FloraM es ()
 updateTarballRootHash releaseId hash =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| tarball_root_hash |]]
-            [field| release_id |]
-        )
-        (toRow (Only $ Just $ display hash) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| tarball_root_hash |]]
+          [field| release_id |]
+      )
+      (toRow (Only $ Just $ display hash) ++ toRow (Only releaseId))
 
 updateTestedWith
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => ReleaseId
   -> Vector Version
   -> UTCTime
   -> FloraM es ()
 updateTestedWith releaseId testedCompilers timestamp =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| tested_with |], [field| updated_at |]]
-            [field| release_id |]
-        )
-        (toRow (Just testedCompilers, timestamp) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| tested_with |], [field| updated_at |]]
+          [field| release_id |]
+      )
+      (toRow (Just testedCompilers, timestamp) ++ toRow (Only releaseId))
 
 updateTarballArchiveHash
-  :: (BlobStoreAPI :> es, IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (BlobStoreAPI :> es, IOE :> es, WriteDB :> es)
   => ReleaseId
   -> LazyByteString
   -> FloraM es ()
 updateTarballArchiveHash releaseId (toStrict -> content) = do
   let hash = Sha256Sum . SHA.hash $ content
   put hash content
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| tarball_archive_hash |]]
-            [field| release_id |]
-        )
-        (toRow (Only . Just $ display hash) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| tarball_archive_hash |]]
+          [field| release_id |]
+      )
+      (toRow (Only . Just $ display hash) ++ toRow (Only releaseId))
 
 linkPackageUploaderToImportedRelease
-  :: (Error ImportError :> es, IOE :> es, Labeled ReadOnly WithConnection :> es, Labeled ReadWrite WithConnection :> es, Reader FloraEnv :> es)
+  :: (Error ImportError :> es, IOE :> es, ReadDB :> es, WriteDB :> es)
   => ReleaseId
   -> Text
   -> FloraM es ()
 linkPackageUploaderToImportedRelease releaseId username = do
-  FloraEnv{pool} <- Reader.ask
   mPackageIndexId <- Query.getReleasePackageIndex releaseId
   case mPackageIndexId of
     Nothing -> Error.throwError $ CouldNotFindPackageIndexForRelease releaseId
     Just packageIndexId -> do
       mPackageUploader <-
-        withReadOnlyPool pool $
-          Query.getPackageUploaderByUsernameAndIndex
-            username
-            packageIndexId
+        Query.getPackageUploaderByUsernameAndIndex
+          username
+          packageIndexId
       case mPackageUploader of
         Just packageUploader ->
           updateReleaseUploader releaseId packageUploader.packageUploaderId
@@ -210,26 +199,25 @@ linkPackageUploaderToImportedRelease releaseId username = do
           updateReleaseUploader releaseId packageUploaderDAO.packageUploaderId
 
 updateReleaseUploader
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => ReleaseId
   -> PackageUploaderId
   -> FloraM es ()
 updateReleaseUploader releaseId packageUploaderId =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| uploader_id |]]
-            [field| release_id |]
-        )
-        (toRow (Only packageUploaderId) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| uploader_id |]]
+          [field| release_id |]
+      )
+      (toRow (Only packageUploaderId) ++ toRow (Only releaseId))
 
 setReleasesDeprecationMarker
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es)
+  :: (IOE :> es, WriteDB :> es)
   => Vector (Bool, ReleaseId)
   -> FloraM es ()
 setReleasesDeprecationMarker releaseVersions =
-  labeled @ReadWrite @WithConnection $ void $ executeMany q (releaseVersions & Vector.toList)
+  void $ executeMany q (releaseVersions & Vector.toList)
   where
     q =
       [sql|
@@ -239,13 +227,12 @@ setReleasesDeprecationMarker releaseVersions =
     WHERE r0.release_id = (upd.y :: uuid)
     |]
 
-setArchiveChecksum :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => ReleaseId -> Text -> FloraM es ()
+setArchiveChecksum :: (IOE :> es, WriteDB :> es) => ReleaseId -> Text -> FloraM es ()
 setArchiveChecksum releaseId sha256Hash =
-  labeled @ReadWrite @WithConnection $
-    void $
-      execute
-        ( _updateFieldsBy @Release
-            [[field| archive_checksum |]]
-            [field| release_id |]
-        )
-        (toRow (Only sha256Hash) ++ toRow (Only releaseId))
+  void $
+    execute
+      ( _updateFieldsBy @Release
+          [[field| archive_checksum |]]
+          [field| release_id |]
+      )
+      (toRow (Only sha256Hash) ++ toRow (Only releaseId))

--- a/src/core/Flora/Model/User/Query.hs
+++ b/src/core/Flora/Model/User/Query.hs
@@ -10,20 +10,18 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Entity.Types
 import Database.PostgreSQL.Simple (Only (Only))
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 
 import Flora.Database
 import Flora.Model.User
 
-getUserById :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => UserId -> Eff es (Maybe User)
-getUserById userId = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @User [primaryKey @User]) (Only userId)
+getUserById :: (IOE :> es, ReadDB :> es) => UserId -> Eff es (Maybe User)
+getUserById userId = queryOne (_selectWhere @User [primaryKey @User]) (Only userId)
 
-getUserByUsername :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Maybe User)
-getUserByUsername username = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @User [[field| username |]]) (Only username)
+getUserByUsername :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Maybe User)
+getUserByUsername username = queryOne (_selectWhere @User [[field| username |]]) (Only username)
 
-getUserByEmail :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Text -> Eff es (Maybe User)
-getUserByEmail email = labeled @ReadOnly @WithConnection $ queryOne (_selectWhere @User [[field| email |]]) (Only email)
+getUserByEmail :: (IOE :> es, ReadDB :> es) => Text -> Eff es (Maybe User)
+getUserByEmail email = queryOne (_selectWhere @User [[field| email |]]) (Only email)
 
-getAllUsers :: (IOE :> es, Labeled ReadOnly WithConnection :> es) => Eff es (Vector User)
-getAllUsers = labeled @ReadOnly @WithConnection $ Vector.fromList <$> query_ (_select @User)
+getAllUsers :: (IOE :> es, ReadDB :> es) => Eff es (Vector User)
+getAllUsers = Vector.fromList <$> query_ (_select @User)

--- a/src/core/Flora/Model/User/Update.hs
+++ b/src/core/Flora/Model/User/Update.hs
@@ -16,8 +16,6 @@ import Database.PostgreSQL.Entity
 import Database.PostgreSQL.Simple (Only (Only))
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Effectful
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Effectful.Reader.Static (Reader)
 import Effectful.Reader.Static qualified as Reader
 import Effectful.Time (Time)
@@ -33,14 +31,15 @@ addAdmin :: (IOE :> es, Reader FloraEnv :> es, Time :> es) => AdminCreationForm 
 addAdmin form = do
   FloraEnv{pool} <- Reader.ask
   adminUser <- mkAdmin form
-  withReadWritePool pool $ insertUser adminUser
-  withReadWritePool pool $ unlockAccount adminUser.userId
+  withReadWritePool pool $ do
+    insertUser adminUser
+    unlockAccount adminUser.userId
   pure adminUser
 
-lockAccount :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Time :> es) => UserId -> FloraM es ()
+lockAccount :: (IOE :> es, Time :> es, WriteDB :> es) => UserId -> FloraM es ()
 lockAccount userId = do
   ts <- Time.currentTime
-  labeled @ReadWrite @WithConnection $ void $ execute q (ts, userId)
+  void $ execute q (ts, userId)
   where
     q =
       [sql|
@@ -50,10 +49,10 @@ lockAccount userId = do
         where u.user_id = ?;
       |]
 
-unlockAccount :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Time :> es) => UserId -> FloraM es ()
+unlockAccount :: (IOE :> es, Time :> es, WriteDB :> es) => UserId -> FloraM es ()
 unlockAccount userId = do
   ts <- Time.currentTime
-  labeled @ReadWrite @WithConnection $ void $ execute q (ts, userId)
+  void $ execute q (ts, userId)
   where
     q =
       [sql|
@@ -63,20 +62,20 @@ unlockAccount userId = do
         where u.user_id = ?
       |]
 
-insertUser :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => User -> FloraM es ()
-insertUser user = labeled @ReadWrite @WithConnection $ void $ execute (_insert @User) user
+insertUser :: (IOE :> es, WriteDB :> es) => User -> FloraM es ()
+insertUser user = void $ execute (_insert @User) user
 
-deleteUser :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => UserId -> FloraM es ()
-deleteUser userId = labeled @ReadWrite @WithConnection $ void $ execute (_delete @User) (Only userId)
+deleteUser :: (IOE :> es, WriteDB :> es) => UserId -> FloraM es ()
+deleteUser userId = void $ execute (_delete @User) (Only userId)
 
 setupTOTP
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Time :> es)
+  :: (IOE :> es, Time :> es, WriteDB :> es)
   => UserId
   -> HMAC.AuthenticationKey
   -> FloraM es ()
 setupTOTP userId key = do
   ts <- Time.currentTime
-  labeled @ReadWrite @WithConnection $ void $ execute q (key, ts, userId)
+  void $ execute q (key, ts, userId)
   where
     q =
       [sql|
@@ -87,12 +86,12 @@ setupTOTP userId key = do
       |]
 
 confirmTOTP
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Time :> es)
+  :: (IOE :> es, Time :> es, WriteDB :> es)
   => UserId
   -> FloraM es ()
 confirmTOTP userId = do
   ts <- Time.currentTime
-  labeled @ReadWrite @WithConnection $ void $ execute q (ts, userId)
+  void $ execute q (ts, userId)
   where
     q =
       [sql|
@@ -103,12 +102,12 @@ confirmTOTP userId = do
       |]
 
 unSetTOTP
-  :: (IOE :> es, Labeled ReadWrite WithConnection :> es, Time :> es)
+  :: (IOE :> es, Time :> es, WriteDB :> es)
   => UserId
   -> FloraM es ()
 unSetTOTP userId = do
   ts <- Time.currentTime
-  labeled @ReadWrite @WithConnection $ void $ execute q (ts, userId)
+  void $ execute q (ts, userId)
   where
     q =
       [sql|

--- a/src/jobs-worker/FloraJobs/Runner.hs
+++ b/src/jobs-worker/FloraJobs/Runner.hs
@@ -212,13 +212,13 @@ fetchUploadInformation payload@UploadInformationJobPayload{packageName, packageV
         if packageInfo.metadataRevision == 0
           then do
             withReadWritePool pool $ Update.updateUploadTime releaseId packageInfo.uploadedAt
-            withReadWritePool pool $ withReadOnlyPool pool $ Update.linkPackageUploaderToImportedRelease releaseId packageInfo.uploader
+            withReadWritePool pool $ Update.linkPackageUploaderToImportedRelease releaseId packageInfo.uploader
           else do
             Hackage.request (Hackage.getPackageWithRevision requestPayload 0) >>= \case
               Right originalPackageInfo -> do
                 withReadWritePool pool $ Update.updateRevisionTime releaseId packageInfo.uploadedAt
                 withReadWritePool pool $ Update.updateUploadTime releaseId originalPackageInfo.uploadedAt
-                withReadWritePool pool $ withReadOnlyPool pool $ Update.linkPackageUploaderToImportedRelease releaseId packageInfo.uploader
+                withReadWritePool pool $ Update.linkPackageUploaderToImportedRelease releaseId packageInfo.uploader
               Left e -> handleClientError e
   where
     handleClientError :: ClientError -> JobsRunner ()
@@ -443,8 +443,8 @@ fetchPackageMaintainers packageName = do
               namespace
               packageName
               (\_ _ -> Error.throwError (CouldNotFindPackage namespace packageName))
-        packageUploaders <- forM (Vector.toList maintainers) $ \(HackagePackageMaintainer username) ->
-          withReadOnlyPool pool $
+        packageUploaders <- withReadOnlyPool pool $
+          forM (Vector.toList maintainers) $ \(HackagePackageMaintainer username) ->
             guardThatPackageUploaderExists
               username
               packageIndex.packageIndexId
@@ -489,9 +489,10 @@ fetchPackageUploaders = do
     Hackage.request Hackage.listHackageUsers >>= \case
       Left e -> handleClientError e
       Right users -> do
-        forM_ users $ \user -> do
-          dao <- mkPackageUploaderDAO user.username packageIndex.packageIndexId Nothing
-          withReadWritePool pool $ Update.insertMaybeExistingPackageUploader dao
+        withReadWritePool pool $
+          forM_ users $ \user -> do
+            dao <- mkPackageUploaderDAO user.username packageIndex.packageIndexId Nothing
+            Update.insertMaybeExistingPackageUploader dao
   where
     handleClientError :: ClientError -> JobsRunner a
     handleClientError e = Arb.throwRetryable (Text.show e)

--- a/src/web/FloraWeb/Common/Auth.hs
+++ b/src/web/FloraWeb/Common/Auth.hs
@@ -81,8 +81,7 @@ requireUserHandler
 requireUserHandler floraEnv req = do
   let cookies = getCookies req
   mbPersistentSessionId <- handlerToEff $ getSessionId cookies
-  mbPersistentSession <- getInTheFuckingSessionShinji floraEnv.pool mbPersistentSessionId
-  mUserInfo <- fetchUser floraEnv.pool mbPersistentSession
+  mUserInfo <- getInTheFuckingSessionShinji floraEnv.pool mbPersistentSessionId
   requestID <- liftIO $ getRequestID req
   (user, sessionId) <- do
     case mUserInfo of
@@ -101,8 +100,7 @@ handler floraEnv req = do
   let cookies = getCookies req
   let theme = getTheme cookies
   mbPersistentSessionId <- handlerToEff $ getSessionId cookies
-  mbPersistentSession <- getInTheFuckingSessionShinji floraEnv.pool mbPersistentSessionId
-  mUserInfo <- fetchUser floraEnv.pool mbPersistentSession
+  mUserInfo <- getInTheFuckingSessionShinji floraEnv.pool mbPersistentSessionId
   requestID <- liftIO $ getRequestID req
   (user, sessionId) <- do
     case mUserInfo of
@@ -122,8 +120,7 @@ requireAdminHandler
 requireAdminHandler floraEnv req = do
   let cookies = getCookies req
   mbPersistentSessionId <- handlerToEff $ getSessionId cookies
-  mbPersistentSession <- getInTheFuckingSessionShinji floraEnv.pool mbPersistentSessionId
-  mUserInfo <- fetchUser floraEnv.pool mbPersistentSession
+  mUserInfo <- getInTheFuckingSessionShinji floraEnv.pool mbPersistentSessionId
   requestID <- liftIO $ getRequestID req
   (user, sessionId) <- do
     case mUserInfo of
@@ -164,38 +161,26 @@ getSessionId cookies =
         Nothing -> pure Nothing
         Just sessionId -> pure (Just sessionId)
 
+-- | Resolve the session and its user in a single read-only transaction, so an
+-- authenticated request draws one pooled connection instead of two.
 getInTheFuckingSessionShinji
-  :: IOE :> es
+  :: (Error ServerError :> es, IOE :> es)
   => Pool PG.Connection
   -> Maybe PersistentSessionId
-  -> FloraM es (Maybe PersistentSession)
+  -> FloraM es (Maybe (User, PersistentSession))
 getInTheFuckingSessionShinji _ Nothing = pure Nothing
 getInTheFuckingSessionShinji pool (Just persistentSessionId) = do
-  result <- withReadOnlyPool pool $ getPersistentSession persistentSessionId
+  result <- withReadOnlyPool pool $ do
+    mUserSession <- getPersistentSession persistentSessionId
+    case mUserSession of
+      Nothing -> pure Nothing
+      Just userSession -> do
+        mUser <- getUserById userSession.userId
+        pure (Just (userSession, mUser))
   case result of
     Nothing -> pure Nothing
-    (Just userSession) -> pure (Just userSession)
-
-fetchUser
-  :: (Error ServerError :> es, IOE :> es)
-  => Pool PG.Connection
-  -> Maybe PersistentSession
-  -> FloraM es (Maybe (User, PersistentSession))
-fetchUser _ Nothing = pure Nothing
-fetchUser pool (Just userSession) = do
-  user <- lookupUser pool userSession.userId
-  pure (Just (user, userSession))
-
-lookupUser
-  :: (Error ServerError :> es, IOE :> es)
-  => Pool PG.Connection
-  -> UserId
-  -> FloraM es User
-lookupUser pool uid = do
-  result <- withReadOnlyPool pool $ getUserById uid
-  case result of
-    Nothing -> throwError (err403{errBody = "Invalid Cookie"})
-    (Just user) -> pure user
+    Just (_, Nothing) -> throwError (err403{errBody = "Invalid Cookie"})
+    Just (userSession, Just user) -> pure (Just (user, userSession))
 
 handlerToEff
   :: forall (es :: [Effect]) (a :: Type)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,8 +4,6 @@ import Control.Monad.Extra
 import Effectful
 import Effectful.Fail
 import Effectful.FileSystem
-import Effectful.Labeled
-import Effectful.PostgreSQL
 import Options.Applicative
 import RequireCallStack
 import Sel.Hashing.Password qualified as Sel
@@ -76,8 +74,8 @@ specs fixtures =
   , UserSpec.spec fixtures
   ]
 
-cleanUp :: (IOE :> es, Labeled ReadWrite WithConnection :> es) => Eff es ()
-cleanUp = labeled @ReadWrite @WithConnection $ do
+cleanUp :: (IOE :> es, WriteDB :> es) => Eff es ()
+cleanUp = do
   void $ execute "DELETE FROM blob_relations" ()
   void $ execute "DELETE FROM package_categories" ()
   void $ execute "DELETE FROM categories" ()

--- a/weeder.toml
+++ b/weeder.toml
@@ -1,0 +1,9 @@
+roots = ["Main.main","^Paths_.*"]
+
+type-class-roots = false
+
+root-instances = [{ class = "\\.IsString$" },{ class = "\\.IsList$" }]
+
+unused-types = false
+
+root-modules = []


### PR DESCRIPTION
This PR pulls out the big guns. It introduces a new pair of effects to properly separate read-only and read-write connections, by leveraging the underlying postgresql library in order to start read-only transactions.

Moreover, extraneous concurrency is ditched because database connections are the limiting factor.

A couple of helpers also reduce the visual clutter of queries.