### PR TITLE
[FLORA-288] Hide 2FA/TOTP input on login page by default

### DIFF
--- a/app/jobs/Main.hs
+++ b/app/jobs/Main.hs
@@ -27,7 +27,7 @@ import Network.Wai.Handler.Warp
   )
 import Network.Wai.Middleware.Prometheus qualified as WaiMetrics
 import NoThunks.Class
-import Options.Applicative
+import Options.Applicative (execParser)
 import Prometheus qualified as P
 import Prometheus.Metric.GHC qualified as P
 import RequireCallStack

--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -24,6 +24,7 @@ import Effectful.Log
 import Effectful.Reader.Static qualified as Reader
 import Log qualified
 import NoThunks.Class
+import Options.Applicative (execParser)
 import RequireCallStack
 import System.Exit
 import System.IO
@@ -36,7 +37,6 @@ import Flora.Model.PackageIndex.Types
 import Flora.Monad
 import FloraJobs.Scheduler (checkIfIndexRefreshJobIsPlanned)
 import FloraWeb.Server
-import Options.Applicative (execParser)
 
 main :: IO ()
 main = do

--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -24,7 +24,6 @@ import Effectful.Log
 import Effectful.Reader.Static qualified as Reader
 import Log qualified
 import NoThunks.Class
-import Options.Applicative
 import RequireCallStack
 import System.Exit
 import System.IO
@@ -37,6 +36,7 @@ import Flora.Model.PackageIndex.Types
 import Flora.Monad
 import FloraJobs.Scheduler (checkIfIndexRefreshJobIsPlanned)
 import FloraWeb.Server
+import Options.Applicative (execParser)
 
 main :: IO ()
 main = do

--- a/assets/css/1-base/forms.css
+++ b/assets/css/1-base/forms.css
@@ -27,9 +27,13 @@ textarea {
 input::placeholder,
 select::placeholder,
 textarea::placeholder {
-	color: var(--color-text-tertiary)
+	color: var(--color-text-tertiary);
 }
 
 .label {
 	display: block;
+}
+
+input[type="checkbox"]:has(+ label) {
+	margin-inline-end: var(--space-2);
 }

--- a/changelog.d/1116
+++ b/changelog.d/1116
@@ -1,0 +1,10 @@
+synopsis: Hide 2FA/TOTP input on login page by default
+prs: #1141
+issues: #1116
+
+description: {
+
+- Added spacing between checkbox and label
+- Fixed 2fa toggle behaviour to hide the input by default
+
+}

--- a/flora.cabal
+++ b/flora.cabal
@@ -112,8 +112,8 @@ library
     Distribution.Orphans.ConfVar
     Distribution.Orphans.PackageFlag
     Distribution.Orphans.Version
-    Flora.DB.Exception
     Flora.Database
+    Flora.DB.Exception
     Flora.Environment
     Flora.Environment.Config
     Flora.Environment.Env
@@ -190,8 +190,6 @@ library
     Servant.API.ContentTypes.GZip
 
   build-depends:
-    Cabal-syntax,
-    JuicyPixels,
     aeson,
     arbiter-simple,
     attoparsec,
@@ -199,6 +197,7 @@ library
     base16-bytestring,
     base64,
     bytestring,
+    Cabal-syntax,
     commonmark,
     commonmark-pandoc,
     containers,
@@ -224,6 +223,7 @@ library
     http-api-data,
     http-media,
     iso8601-time,
+    JuicyPixels,
     kdl-hs,
     log-base,
     log-effectful,
@@ -306,9 +306,9 @@ library flora-advisories
     Advisories.Model.Affected.Update
 
   build-depends:
-    Cabal-syntax,
     aeson,
     base,
+    Cabal-syntax,
     cvss,
     deepseq,
     effectful-core,
@@ -416,8 +416,6 @@ library flora-web
     FloraWeb.Types
 
   build-depends:
-    Cabal-syntax,
-    PyF,
     aeson,
     arbiter-servant,
     arbiter-servant-ui,
@@ -425,6 +423,7 @@ library flora-web
     base ^>=4.20,
     base32,
     bytestring,
+    Cabal-syntax,
     chronos,
     cmark-gfm,
     colourista,
@@ -474,6 +473,7 @@ library flora-web
     prometheus-effectful,
     prometheus-metrics-ghc,
     prometheus-proc,
+    PyF,
     raven-haskell,
     require-callstack,
     resource-pool,
@@ -523,7 +523,6 @@ library flora-jobs
     FloraJobs.Types
 
   build-depends:
-    Cabal-syntax,
     aeson,
     arbiter-core,
     arbiter-simple,
@@ -531,6 +530,7 @@ library flora-jobs
     base,
     blaze-markup,
     bytestring,
+    Cabal-syntax,
     commonmark,
     commonmark-extensions,
     commonmark-pandoc,
@@ -659,10 +659,9 @@ executable flora-cli
   other-modules: DesignSystem
   hs-source-dirs: app/cli
   build-depends:
-    Cabal-syntax,
-    PyF,
     base,
     bytestring,
+    Cabal-syntax,
     cvss,
     effectful,
     effectful-core,
@@ -685,6 +684,7 @@ executable flora-cli
     optparse-applicative,
     process,
     prometheus-effectful,
+    PyF,
     require-callstack,
     sel,
     text,
@@ -704,10 +704,10 @@ test-suite flora-test
   main-is: Main.hs
   hs-source-dirs: test
   build-depends:
-    Cabal-syntax,
     aeson,
     base,
     bytestring,
+    Cabal-syntax,
     containers,
     effectful,
     effectful-core,

--- a/src/web/FloraWeb/Components/Utils.hs
+++ b/src/web/FloraWeb/Components/Utils.hs
@@ -48,7 +48,7 @@ ariaHidden = makeAttributes "aria-hidden"
 
 -- Prefer these ones as they are integrated with AlpineJS
 ariaControls_ :: Text -> Attributes
-ariaControls_ = makeAttributes ":aria-controls"
+ariaControls_ = makeAttributes "aria-controls"
 
 ariaExpanded_ :: Text -> Attributes
 ariaExpanded_ = makeAttributes ":aria-expanded"

--- a/src/web/FloraWeb/Components/Utils.hs
+++ b/src/web/FloraWeb/Components/Utils.hs
@@ -109,6 +109,11 @@ xBind_
   -> Attributes
 xBind_ attr = makeAttributes ("x-bind:" <> attr)
 
+-- | x-ref
+-- Target DOM elements directly
+xRef_ :: Text -> Attributes
+xRef_ = makeAttributes "x-ref"
+
 -- | x-init
 -- Run code when an element is initialized by Alpine
 xInit_ :: Text -> Attributes

--- a/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
@@ -19,7 +19,7 @@ newSession = do
       , method_ "POST"
       , class_ formClasses
       , xData_ "{ open: false }"
-      , xInit_ "const sync = () => { open = $refs.useTotp.checked }; sync(); window.addEventListener('pageshow', sync);"
+      , xInit_ "open = $refs.useTotp.checked"
       ]
       $ do
         div_ [class_ "flow flow--small"] $ do

--- a/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
@@ -2,6 +2,7 @@ module FloraWeb.Pages.Templates.Screens.Sessions where
 
 import Lucid
 
+import FloraWeb.Components.Utils
 import FloraWeb.Pages.Templates.Types
 
 newSession :: FloraHTML
@@ -12,7 +13,14 @@ newSession = do
       div_ [class_ "flow"] $ do
         h1_ [class_ "pageHead-title text-break text-center"] "Login"
   section_ [class_ "wrapper wrapper--small inset-large flow flow--large", id_ "content"] $ do
-    form_ [class_ "flow", action_ "/sessions/new", method_ "POST", class_ formClasses] $ do
+    form_
+      [ class_ "flow"
+      , action_ "/sessions/new"
+      , method_ "POST"
+      , class_ formClasses
+      , xData_ "{ open: false }"
+      , xInit_ "const sync = () => { open = $refs.useTotp.checked }; sync(); window.addEventListener('pageshow', sync);"
+      ] $ do
       div_ [class_ "flow flow--small"] $ do
         label_ [class_ "sr-only", for_ "email"] "Email address"
         input_
@@ -40,10 +48,16 @@ newSession = do
           [ id_ "use_totp"
           , name_ "use_totp"
           , type_ "checkbox"
+          , xRef_ "useTotp"
+          , ariaControls_ "totp_wrap"
+          , xModel_ [] "open"
           ]
         label_ [for_ "use_totp"] "Use two-factor authentication"
-      -- TODO: [non-urgent] Show only when use_totp input is checked (with AlpineJS)
-      div_ [class_ "flow flow--small"] $ do
+      div_
+        [ id_ "totp_wrap"
+        , class_ "flow flow--small"
+        , xBind_ "hidden" "!open"
+        , xBind_ "inert" "!open"] $ do
         label_ [class_ "label", for_ "totp"] "Two-factor code"
         input_
           [ id_ "totp"

--- a/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
@@ -18,8 +18,9 @@ newSession = do
       , action_ "/sessions/new"
       , method_ "POST"
       , class_ formClasses
-      , xData_ "{ open: false }"
-      , xInit_ "open = $refs.useTotp.checked"
+      , xData_ "{ open: false, sync() { this.open = this.$refs.useTotp.checked; }}"
+      , xInit_ "sync()"
+      , xOn_ "pageshow.window" "sync()"
       ]
       $ do
         div_ [class_ "flow flow--small"] $ do

--- a/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
+++ b/src/web/FloraWeb/Pages/Templates/Screens/Sessions.hs
@@ -20,52 +20,55 @@ newSession = do
       , class_ formClasses
       , xData_ "{ open: false }"
       , xInit_ "const sync = () => { open = $refs.useTotp.checked }; sync(); window.addEventListener('pageshow', sync);"
-      ] $ do
-      div_ [class_ "flow flow--small"] $ do
-        label_ [class_ "sr-only", for_ "email"] "Email address"
-        input_
-          [ id_ "email"
-          , name_ "email"
-          , type_ "email"
-          , autocomplete_ "email"
-          , required_ ""
-          , placeholder_ "Email address"
-          , class_ "w100"
+      ]
+      $ do
+        div_ [class_ "flow flow--small"] $ do
+          label_ [class_ "sr-only", for_ "email"] "Email address"
+          input_
+            [ id_ "email"
+            , name_ "email"
+            , type_ "email"
+            , autocomplete_ "email"
+            , required_ ""
+            , placeholder_ "Email address"
+            , class_ "w100"
+            ]
+        div_ [class_ "flow flow--small"] $ do
+          label_ [class_ "sr-only", for_ "password"] "Email address"
+          input_
+            [ id_ "password"
+            , name_ "password"
+            , type_ "password"
+            , autocomplete_ "current-password"
+            , required_ ""
+            , placeholder_ "Password"
+            , class_ "w100 password"
+            ]
+        div_ [class_ "flow flow--small"] $ do
+          input_
+            [ id_ "use_totp"
+            , name_ "use_totp"
+            , type_ "checkbox"
+            , xRef_ "useTotp"
+            , ariaControls_ "totp_wrap"
+            , xModel_ [] "open"
+            ]
+          label_ [for_ "use_totp"] "Use two-factor authentication"
+        div_
+          [ id_ "totp_wrap"
+          , class_ "flow flow--small"
+          , xBind_ "hidden" "!open"
+          , xBind_ "inert" "!open"
           ]
-      div_ [class_ "flow flow--small"] $ do
-        label_ [class_ "sr-only", for_ "password"] "Email address"
-        input_
-          [ id_ "password"
-          , name_ "password"
-          , type_ "password"
-          , autocomplete_ "current-password"
-          , required_ ""
-          , placeholder_ "Password"
-          , class_ "w100 password"
-          ]
-      div_ [class_ "flow flow--small"] $ do
-        input_
-          [ id_ "use_totp"
-          , name_ "use_totp"
-          , type_ "checkbox"
-          , xRef_ "useTotp"
-          , ariaControls_ "totp_wrap"
-          , xModel_ [] "open"
-          ]
-        label_ [for_ "use_totp"] "Use two-factor authentication"
-      div_
-        [ id_ "totp_wrap"
-        , class_ "flow flow--small"
-        , xBind_ "hidden" "!open"
-        , xBind_ "inert" "!open"] $ do
-        label_ [class_ "label", for_ "totp"] "Two-factor code"
-        input_
-          [ id_ "totp"
-          , name_ "totp"
-          , type_ "text"
-          , pattern_ "0-9]+"
-          , autocomplete_ "off"
-          , class_ "w100"
-          ]
-      div_ [class_ "flow flow--small"] $ do
-        button_ [class_ "btn btn--big w100", type_ "submit"] "Log In"
+          $ do
+            label_ [class_ "label", for_ "totp"] "Two-factor code"
+            input_
+              [ id_ "totp"
+              , name_ "totp"
+              , type_ "text"
+              , pattern_ "0-9]+"
+              , autocomplete_ "off"
+              , class_ "w100"
+              ]
+        div_ [class_ "flow flow--small"] $ do
+          button_ [class_ "btn btn--big w100", type_ "submit"] "Log In"


### PR DESCRIPTION
## Proposed changes

- Made the 2fa input hidden by default, visible on checkbox change
- Fixed the Alpine js binding for `ariaControls_`: `aria-controls` can be just a regular attribute
- Fixed/added spacing between the checkbox and label

## Contributor checklist

- [x] My PR is related to #1116 
- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [x] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [x] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
