### PR TITLE
Hide NoSuchThing/kevent from exception logs

### DIFF
--- a/src/web/FloraWeb/Common/Tracing.hs
+++ b/src/web/FloraWeb/Common/Tracing.hs
@@ -4,6 +4,7 @@ import Control.Exception (AsyncException (..), Exception (..), SomeException, th
 import Control.Monad (when)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Char8 (unpack)
+import Data.List (isInfixOf)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text.Display (display)
@@ -14,7 +15,7 @@ import GHC.IO.Exception (IOErrorType (..))
 import Log qualified
 import Network.Wai
 import Network.Wai.Handler.Warp
-import System.IO.Error (ioeGetErrorType)
+import System.IO.Error (ioeGetErrorType, ioeGetLocation)
 import System.Log.Raven
 import System.Log.Raven.Transport.HttpConduit (sendRecord)
 import System.Log.Raven.Types (SentryLevel (..), SentryRecord (..))
@@ -68,6 +69,10 @@ shouldDisplayException exception
   | Just (_ :: InvalidRequest) <- fromException exception = False
   | Just (ioeGetErrorType -> et) <- fromException exception
   , et == ResourceVanished || et == InvalidArgument =
+      False
+  | Just ioe <- fromException exception
+  , ioeGetErrorType ioe == NoSuchThing
+  , "kevent" `isInfixOf` ioeGetLocation ioe =
       False
   | otherwise = True
 


### PR DESCRIPTION
NoSuchThing from kevent can be linked to connection teardown where a connection is dropped mid-request. This is BSD-specific behaviour.

## Proposed changes

## Contributor checklist

- [ ] My PR is related to \<insert ticket number>
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
