### PR TITLE
Batch dependency and requirement inserts during package imports

### DIFF
--- a/src/core/Flora/Database.hs
+++ b/src/core/Flora/Database.hs
@@ -18,6 +18,7 @@ module Flora.Database
   , execute_
   , executeMany
   , upsert
+  , upsertMany
 
     -- * Interpreters
   , withReadOnlyPool
@@ -97,6 +98,10 @@ execute_ q = send (Execute_ q)
 executeMany :: (ToRow q, WriteDB :> es) => Query -> [q] -> Eff es Int64
 executeMany q params = send (ExecuteMany q params)
 
+upsertQuery :: forall e. Entity e => Vector Field -> Query
+upsertQuery fieldsToReplace =
+  _insert @e <> _onConflictDoUpdate (Vector.singleton (primaryKey @e)) fieldsToReplace
+
 -- | Insert an entity, replacing the given fields on primary-key conflict.
 upsert
   :: forall e es values
@@ -107,9 +112,18 @@ upsert
   -- ^ Fields to replace in case of conflict
   -> Eff es ()
 upsert entity fieldsToReplace =
-  void $ execute (_insert @e <> _onConflictDoUpdate conflictTarget fieldsToReplace) entity
-  where
-    conflictTarget = Vector.singleton $ primaryKey @e
+  void $ execute (upsertQuery @e fieldsToReplace) entity
+
+-- | Bulk upsert. Callers must not pass two rows with the same primary key
+-- in one batch, because `ON CONFLICT DO UPDATE` rejects a repeated key.
+upsertMany
+  :: forall e es values
+   . (Entity e, ToRow values, WriteDB :> es)
+  => [values]
+  -> Vector Field
+  -> Eff es ()
+upsertMany entities fieldsToReplace =
+  void $ executeMany (upsertQuery @e fieldsToReplace) entities
 
 -- | Discharge 'ReadDB' against a fixed connection.
 interpretReadDB :: IOE :> es => Connection -> Eff (ReadDB ': es) a -> Eff es a

--- a/src/core/Flora/Import/Package.hs
+++ b/src/core/Flora/Import/Package.hs
@@ -291,7 +291,7 @@ persistImportOutput (ImportOutput package categories release components) = State
         categoriesByName <- catMaybes <$> traverse Query.getCategoryByName categories
         forM_
           categoriesByName
-          (\c -> Update.addToCategoryByName package.packageId c.name)
+          (\c -> Update.addToCategory package.packageId c.categoryId)
         if Set.member (package.namespace, package.name, release.version) packageCache
           then do
             Log.logInfo "Release already present" $
@@ -305,31 +305,12 @@ persistImportOutput (ImportOutput package categories release components) = State
             Update.upsertRelease package release
             let componentsList = NE.toList $ fmap fst components
             let dependencies = foldMap snd components
-            let dependencyPackages = fmap (.package) dependencies
             Update.upsertPackageComponents componentsList
-            Log.logInfo_ "Inserting dependencies"
-            forM_
-              dependencyPackages
-              ( \p -> do
-                  Log.logInfo_ "Upserting package"
-                  Update.upsertPackage p
-              )
-            forM_ dependencies persistImportDependency
+            Update.bulkInsertUnknownPackages (fmap (.package) dependencies)
+            Update.bulkUpsertRequirements (fmap (.requirement) dependencies)
             unless (null dependencies) sanityCheck
             pure $ Set.insert (package.namespace, package.name, release.version) packageCache
   where
-    persistImportDependency dep = do
-      Log.logInfo "Inserting requirement" $
-        object
-          [ "dependent_namespace" .= display package.namespace
-          , "dependent_name" .= display package.name
-          , "dependent_id" .= display package.packageId
-          , "dependency_namespace" .= display dep.package.namespace
-          , "dependency_name" .= display dep.package.name
-          , "dependency_id" .= display dep.package.packageId
-          ]
-      Update.upsertRequirement dep.requirement
-
     sanityCheck = do
       dependencies <- Query.getAllRequirements release.releaseId
       when (Map.null dependencies) $ do

--- a/src/core/Flora/Model/Category/Update.hs
+++ b/src/core/Flora/Model/Category/Update.hs
@@ -3,17 +3,12 @@
 module Flora.Model.Category.Update where
 
 import Control.Monad (void)
-import Control.Monad.IO.Class
-import Data.Text (Text)
-import Data.Text.IO qualified as T
 import Database.PostgreSQL.Simple.SqlQQ
 import Effectful
 
 import Flora.Database
-import Flora.Model.Category.Query qualified as Query
 import Flora.Model.Category.Types
 import Flora.Model.Package.Types
-import Flora.Monad
 
 insertCategory :: WriteDB :> es => Category -> Eff es ()
 insertCategory category = do
@@ -35,12 +30,3 @@ addToCategory packageId categoryId = (void . execute q) (packageId, categoryId)
         insert into package_categories (package_id, category_id) values (?, ?)
         on conflict do nothing
       |]
-
-addToCategoryByName :: (IOE :> es, ReadDB :> es, WriteDB :> es) => PackageId -> Text -> FloraM es ()
-addToCategoryByName packageId categoryName = do
-  mCategory <- Query.getCategoryByName categoryName
-  case mCategory of
-    Nothing -> do
-      liftIO $ T.putStrLn ("Could not find category " <> categoryName)
-    Just Category{categoryId} -> do
-      addToCategory packageId categoryId

--- a/src/core/Flora/Model/Package/Update.hs
+++ b/src/core/Flora/Model/Package/Update.hs
@@ -3,9 +3,9 @@
 
 module Flora.Model.Package.Update where
 
-import Control.Monad (unless, void)
+import Control.Monad (void)
 import Data.Function ((&))
-import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Database.PostgreSQL.Entity hiding (upsert)
@@ -22,7 +22,7 @@ import Flora.Database
 import Flora.Model.Component.Types (PackageComponent)
 import Flora.Model.Package.Orphans ()
 import Flora.Model.Package.Types
-import Flora.Model.Requirement (Requirement)
+import Flora.Model.Requirement (Requirement (..))
 
 upsertPackage :: (IOE :> es, RequireCallStack, WriteDB :> es) => Package -> Eff es ()
 upsertPackage package =
@@ -41,6 +41,25 @@ upsertPackage package =
   where
     upsertWith entity =
       void $ execute (_insert @Package <> " ON CONFLICT DO NOTHING") entity
+
+-- | Keep the __last__ occurrence of each element by key (as 'Map.fromList'
+-- does) to make a batch safe for a bulk insert.
+dedupOn :: Ord k => (a -> k) -> [a] -> [a]
+dedupOn key = Map.elems . Map.fromList . map (\x -> (key x, x))
+
+-- | Insert many packages unknown packages.
+-- This must not be used to promote a package to
+-- 'FullyImportedPackage' (use 'upsertPackage' for that).
+-- It is for inserting 'UnknownPackage' dependency skeletons without downgrading a package that is already known.
+--
+-- TODO: Probably should label Packages at the type level for their import level?
+bulkInsertUnknownPackages :: (IOE :> es, RequireCallStack, WriteDB :> es) => [Package] -> Eff es ()
+bulkInsertUnknownPackages packages =
+  E.catch
+    (void $ executeMany (_insert @Package <> " ON CONFLICT DO NOTHING") deduped)
+    (\sqlError@(SqlError{}) -> E.throwIO $ sqlErrorToDBException sqlError)
+  where
+    deduped = dedupOn (.packageId) packages
 
 deprecatePackages :: (IOE :> es, RequireCallStack, WriteDB :> es) => Vector DeprecatedPackage -> Eff es ()
 deprecatePackages dp = void $ executeMany q (dp & Vector.map Only & Vector.toList)
@@ -77,9 +96,8 @@ bulkInsertPackageComponents pcs = void $ executeMany (_insert @PackageComponent)
 insertRequirement :: (IOE :> es, RequireCallStack, WriteDB :> es) => Requirement -> Eff es ()
 insertRequirement req = void $ execute (_insert @Requirement) req
 
-upsertRequirement :: (IOE :> es, RequireCallStack, WriteDB :> es) => Requirement -> Eff es ()
-upsertRequirement req = upsert @Requirement req [[field| components |], [field| requirement |]]
-
-bulkInsertRequirements :: (IOE :> es, RequireCallStack, WriteDB :> es) => [Requirement] -> Eff es ()
-bulkInsertRequirements requirements =
-  unless (List.null requirements) $ void (executeMany (_insert @Requirement) requirements)
+bulkUpsertRequirements :: (IOE :> es, RequireCallStack, WriteDB :> es) => [Requirement] -> Eff es ()
+bulkUpsertRequirements requirements =
+  upsertMany @Requirement deduped [[field| components |], [field| requirement |]]
+  where
+    deduped = dedupOn (.requirementId) requirements

--- a/src/core/Flora/Model/Requirement.hs
+++ b/src/core/Flora/Model/Requirement.hs
@@ -31,7 +31,7 @@ import Flora.Model.Package.Types
 newtype RequirementId = RequirementId {getRequirementId :: UUID}
   deriving (Display) via ShowInstance UUID
   deriving
-    (Eq, FromField, FromJSON, NFData, Show, ToField, ToJSON)
+    (Eq, FromField, FromJSON, NFData, Ord, Show, ToField, ToJSON)
     via UUID
 
 deterministicRequirementId :: ComponentId -> PackageId -> RequirementId


### PR DESCRIPTION
Closes #301

persistImportOutput ran per-row loops inside one transaction:
* An upsert per dependency package and per requirement,
* A SELECT on  the category
* A log line per row.

If we collapse the all the iterations into single executeMany statements, we should gain a lot in terms of unnecessary roundtrips.

## Proposed changes

## Contributor checklist

- [ ] My PR is related to \<insert ticket number>
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/flora-pm/flora-server/blob/development/CONTRIBUTING.md)
- [ ] I have inserted my change and a link to this PR in the [CHANGELOG](https://github.com/flora-pm/flora-server/blob/development/CHANGELOG.md)
- [ ] I have updated documentation in `./docs/docs` if a public feature has a behaviour change
