### PR TITLE
Add color converter oklch for old webkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN ghcup install ghc $GHC_VERSION
 RUN ghcup set ghc $GHC_VERSION
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt update
 RUN apt install -y direnv \

--- a/assets/css/0-core/variables.css
+++ b/assets/css/0-core/variables.css
@@ -101,46 +101,42 @@
 	--size-wrapper-small: 35rem;
 
 
-	--color-text-raise: oklch(20% .02 var(--hue-brand));
-	--color-text-default: oklch(35% .02 var(--hue-brand));
-	--color-text-secondary: oklch(45% .02 var(--hue-brand));
-	--color-text-tertiary: oklch(55% .02 var(--hue-brand));
-	--color-text-quaternary: oklch(75% .02 var(--hue-brand));
-	--color-surface-default: oklch(98% .002 var(--hue-brand));
-	--color-surface-secondary: oklch(92% .008 var(--hue-brand));
-	--color-surface-tertiary: oklch(95% .006 var(--hue-brand));
-	--color-surface-hover: oklch(92.701% .0012 var(--hue-brand));
-	--color-stroke-default: oklch(80.126% .02 var(--hue-brand));
-	--color-stroke-secondary: oklch(94.213% .00542 var(--hue-brand));
+	--color-text-raise: oklch(20% 5% var(--hue-brand));
+	--color-text-default: oklch(35% 5% var(--hue-brand));
+	--color-text-secondary: oklch(45% 5% var(--hue-brand));
+	--color-text-tertiary: oklch(55% 5% var(--hue-brand));
+	--color-text-quaternary: oklch(75% 5% var(--hue-brand));
+	--color-surface-default: oklch(98% 0.5% var(--hue-brand));
+	--color-surface-secondary: oklch(92% 2% var(--hue-brand));
+	--color-surface-tertiary: oklch(95% 1.5% var(--hue-brand));
+	--color-surface-hover: oklch(92.701% 0.3% var(--hue-brand));
+	--color-stroke-default: oklch(80.126% 5% var(--hue-brand));
+	--color-stroke-secondary: oklch(94.213% 1.355% var(--hue-brand));
 
 
-	--color-text-brand: oklch(45% .2 var(--hue-brand));
-	--color-text-valid: oklch(45% .2 var(--hue-valid));
-	--color-text-informational: oklch(45% .2 var(--hue-informational));
-	--color-text-warning: oklch(45% .2 var(--hue-warning));
-	--color-text-danger: oklch(45% .2 var(--hue-danger));
+	--color-text-brand: oklch(45% 25% var(--hue-brand));
+	--color-text-valid: oklch(45% 25% var(--hue-valid));
+	--color-text-informational: oklch(45% 25% var(--hue-informational));
+	--color-text-warning: oklch(45% 25% var(--hue-warning));
+	--color-text-danger: oklch(45% 25% var(--hue-danger));
 
-	--color-surface-brand: oklch(95% .016 var(--hue-brand));
-	--color-surface-valid: oklch(97% .028 var(--hue-valid));
-	--color-surface-informational: oklch(97% .028 var(--hue-informational));
-	--color-surface-warning: oklch(97% .028 var(--hue-warning));
-	--color-surface-danger: oklch(97% .028 var(--hue-danger));
+	--color-surface-brand: oklch(95% 4% var(--hue-brand));
+	--color-surface-valid: oklch(97% 7% var(--hue-valid));
+	--color-surface-informational: oklch(97% 7% var(--hue-informational));
+	--color-surface-warning: oklch(97% 7% var(--hue-warning));
+	--color-surface-danger: oklch(97% 7% var(--hue-danger));
 
-	--color-surface-brand-interact: oklch(92% .04 var(--hue-brand));
-	--color-surface-valid-interact: oklch(94% .064 var(--hue-valid));
-	--color-surface-informational-interact: oklch(94% .064 var(--hue-informational));
-	--color-surface-warning-interact: oklch(94% .064 var(--hue-warning));
-	--color-surface-danger-interact: oklch(94% .064 var(--hue-danger));
+	--color-surface-brand-interact: oklch(92% 10% var(--hue-brand));
+	--color-surface-valid-interact: oklch(94% 16% var(--hue-valid));
+	--color-surface-informational-interact: oklch(94% 16% var(--hue-informational));
+	--color-surface-warning-interact: oklch(94% 16% var(--hue-warning));
+	--color-surface-danger-interact: oklch(94% 16% var(--hue-danger));
 
-	--color-border-brand: oklch(from var(--color-surface-brand) calc(l - 0.15) calc(c + 0.025) h);
-	--color-border-valid: oklch(from var(--color-surface-valid) calc(l - 0.15) calc(c + 0.025) h);
-	--color-border-informational: oklch(from var(--color-surface-informational) calc(l - 0.15) calc(c + 0.025) h);
-	--color-border-warning: oklch(from var(--color-surface-warning) calc(l - 0.15) calc(c + 0.025) h);
-	--color-border-danger: oklch(from var(--color-surface-danger) calc(l - 0.15) calc(c + 0.025) h);
 
-	--color-underline-default: oklch(65% .2 var(--hue-brand));
-	--color-underline-secondary: oklch(75% .08 var(--hue-brand));
-	--color-underline-tertiary: oklch(85% .06 var(--hue-brand));
+	--color-underline-default: oklch(65% 25% var(--hue-brand));
+	--color-underline-secondary: oklch(75% 20% var(--hue-brand));
+	--color-underline-tertiary: oklch(85% 15% var(--hue-brand));
+
 
 	--shadow-default: 0 0.25rem 0.5rem var(--color-stroke-secondary);
 
@@ -156,7 +152,7 @@
 	--input-leading: var(--leading-short); /* at least 1.2 to be respected */
 
 
-	--outline-color: oklch(65% .2 var(--hue-brand));
+	--outline-color: oklch(65% 25% var(--hue-brand));
 	--outline-width: .1875rem;
 	--outline-offset: .125rem;
 

--- a/assets/esbuild.config.js
+++ b/assets/esbuild.config.js
@@ -12,6 +12,7 @@ const postcssCopy = require("postcss-copy")({
 });
 const postcssDesignTokenUtils = require("postcss-design-token-utils");
 const designTokensConfig = require("./style-tokens/tokens.js");
+const postcssOklchForOldWebkit = require("postcss-color-oklch-for-old-webkit");
 
 let minify = false;
 let sourcemap = true;
@@ -44,6 +45,7 @@ const pluginsList = () => {
         postcssImport,
         postcssNesting,
         postcssCustomMedia,
+        postcssOklchForOldWebkit,
         autoprefixer,
         postcssCopy,
       ],

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,6 +11,7 @@
     "esbuild-plugin-assets-manifest": "^1.0.7",
     "onchange": "^7.1.0",
     "postcss": "^8.4.31",
+    "postcss-color-oklch-for-old-webkit": "^0.1.3",
     "postcss-copy": "^7.1.0",
     "postcss-custom-media": "^12.0.0",
     "postcss-design-token-utils": "^3.0.1",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -435,6 +435,11 @@ baseline-browser-mapping@^2.9.0:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz#5b09935025bf8a80e29130251e337c6a7fc8cbb9"
   integrity sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==
 
+big.js@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-7.0.1.tgz#c537c649ec6ea11d1306723d13c096ba199aadc4"
+  integrity sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -615,7 +620,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -1447,6 +1452,11 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
+is-url-superb@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
+  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -1847,6 +1857,15 @@ postcss-calc@^10.1.1:
     postcss-selector-parser "^7.0.0"
     postcss-value-parser "^4.2.0"
 
+postcss-color-oklch-for-old-webkit@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-color-oklch-for-old-webkit/-/postcss-color-oklch-for-old-webkit-0.1.3.tgz#1bf1a283f1757d5b6c8f5620ad78843147ddad40"
+  integrity sha512-hPOKI1qY5Ji3qiplEaclodYEHjkTmWtDOIR1SnY0m9HooUj+XFv8JZkehPlNLjx+VyvjGZpNz0NFolX4X1JO0w==
+  dependencies:
+    big.js "^7.0.1"
+    postcss-values-parser "^8.0.0"
+    string-percent "^1.1.0"
+
 postcss-colormin@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-7.0.5.tgz#0c7526289ab3f0daf96a376fd7430fae7258d5cf"
@@ -2107,6 +2126,16 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
+postcss-values-parser@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-8.0.0.tgz#5a5c770cfb9c4711cffde24927e6f61d9dab6166"
+  integrity sha512-gPdtA/H7HgRThMg+QoXJ1EX0EX7zrVF7c3062jaHB4HijLg11QqC2hz9h/nUCZ6O/FljJ+qj2fUvAF2FWhVjFg==
+  dependencies:
+    color-name "^1.1.4"
+    css-tree "^3.1.0"
+    is-url-superb "^4.0.0"
+    quote-unquote "^1.0.0"
+
 postcss@^6.0.3:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
@@ -2136,6 +2165,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quote-unquote@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/quote-unquote/-/quote-unquote-1.0.0.tgz#67a9a77148effeaf81a4d428404a710baaac8a0b"
+  integrity sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -2360,6 +2394,11 @@ static-extend@^0.1.1:
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
+
+string-percent@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/string-percent/-/string-percent-1.1.0.tgz#32931688b1bc0de9a6da3b68a3a70461df72fbc7"
+  integrity sha512-8jwAVURm4fuAHUe88YNgdg/nJAqYQfZrstjeGl1Dy3jAID8qCeBOxO9nVSQR1BbZIK19PR91ZCCn5Ojfc/gBKg==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"


### PR DESCRIPTION
## Proposed changes

Being able to write lightness and chroma value in either percent or decimal formats as we prefer and no longer having to fear failure on Safari older than iOS 16.1-2

### PR includes 
- Upgrade NodeJS v20→v22 (required for plugin below)
- Install PostCSS plugin postcss-color-oklch-for-old-webkit
- Revert the hotfix I made of manually convertir color values on the legacy format needed (decimal for chroma values)
