### PR TITLE
Make the cabal file import pipeline more resilient

### DIFF
--- a/app/cli/Main.hs
+++ b/app/cli/Main.hs
@@ -123,12 +123,12 @@ main = Log.withStdOutLogger $ \logger -> do
       & runErrorWith @(NonEmpty AdvisoryImportError)
         ( \callstack err -> do
             liftIO $ putStrLn $ prettyCallStack callstack
-            pure $ error $ show err
+            E.throwIO $ userError $ show err
         )
       & runErrorWith @ImportError
         ( \callstack err -> do
             liftIO $ putStrLn $ prettyCallStack callstack
-            pure $ error $ show err
+            E.throwIO $ userError $ show err
         )
       & runTrace
       & runPrometheusMetrics env.metrics
@@ -138,6 +138,7 @@ main = Log.withStdOutLogger $ \logger -> do
     exceptionHandlers =
       [ E.Handler $ \(ex :: E.SomeException) -> do
           logAttention "Unhandled exception" $ object ["exception" .= show ex]
+          E.throwIO ex
       ]
 
 parseOptions :: Parser Options

--- a/flora.cabal
+++ b/flora.cabal
@@ -750,6 +750,7 @@ test-suite flora-test
     sel,
     servant,
     servant-client,
+    streamly-core,
     tar,
     tasty,
     tasty-hunit,

--- a/src/core/Flora/Domain/Import/Package.hs
+++ b/src/core/Flora/Domain/Import/Package.hs
@@ -389,7 +389,7 @@ extractPackageDataFromCabal packageIndex indexPackages uploadTime mUsername gene
         object
           [ "package_name" .= display packageName
           , "index" .= packageIndex.repository
-          , "index_packages" .= indexPackages
+          , "indexes_consulted" .= fmap (fmap Set.size) indexPackages
           ]
       Error.throwError $ CouldNotSelectNamespace packageIndex.repository packageName
     Just namespace -> do
@@ -486,8 +486,8 @@ extractPackageDataFromCabal packageIndex indexPackages uploadTime mUsername gene
               <> benchmarks
       case NE.nonEmpty components' of
         Nothing -> do
-          Log.logAttention "Empty dependencies" $ object ["package" .= package]
-          extractPackageDataFromCabal packageIndex indexPackages uploadTime mUsername genericDesc
+          Log.logAttention "No importable components" $ object ["package" .= package]
+          Error.throwError $ NoImportableComponents namespace package.name release.version
         Just components -> pure $ ImportOutput package categories release components
 
 determinePackageUploaderId :: (IOE :> es, ReadDB :> es, WriteDB :> es) => Maybe Text -> PackageIndexId -> Eff es (Maybe PackageUploaderId)

--- a/src/core/Flora/Domain/Import/Package/Bulk/Archive.hs
+++ b/src/core/Flora/Domain/Import/Package/Bulk/Archive.hs
@@ -14,7 +14,6 @@ import Codec.Archive.Tar.Index qualified as Tar
 import Codec.Compression.GZip qualified as GZip
 import Control.Monad
 import Data.Aeson
-import Data.ByteString (StrictByteString)
 import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Lazy qualified as BL
 import Data.List (isSuffixOf)
@@ -46,7 +45,7 @@ import Streamly.Data.Stream.Prelude qualified as Streamly
 import System.FilePath
 
 import Flora.Domain.Import.Package.Bulk.Stream
-import Flora.Domain.Import.Types (ImportError (..), ImportFileType (..))
+import Flora.Domain.Import.Types (ImportError (..), ImportFileType (..), ImportSubject)
 import Flora.Environment.Env
 import Flora.Model.Package.Types qualified as Flora
 import Flora.Model.PackageIndex.Guard
@@ -73,14 +72,12 @@ importFromArchive repositoryName indexDependencies indexArchiveBasePath = do
   let indexArchivePath = indexArchiveBasePath <> "/" <> Text.unpack repositoryName <> "/01-index.tar.gz"
   entries <- Tar.read . GZip.decompress <$> liftIO (BL.readFile indexArchivePath)
   indexPackages <- do
-    let Right localPackages = buildPackageListFromArchive entries
-    when (null localPackages) $ error $ "Index " <> Text.unpack repositoryName <> " has no entries!"
+    localPackages <- packageListOrThrow repositoryName entries
     dependencyPackages <- forM indexDependencies $ \dep -> do
       let depArchivePath = indexArchiveBasePath <> "/" <> Text.unpack dep <> "/01-index.tar.gz"
       indexDependencyEntries <- Tar.read . GZip.decompress <$> liftIO (BL.readFile depArchivePath)
-      let Right indexPackages = buildPackageListFromArchive indexDependencyEntries
-      when (null indexPackages) $ error $ "Index dependency " <> Text.unpack dep <> " has no entries!"
-      pure (dep, indexPackages)
+      depPackages <- packageListOrThrow dep indexDependencyEntries
+      pure (dep, depPackages)
     pure $ (repositoryName, localPackages) `Vector.cons` dependencyPackages
 
   packageIndex <- guardThatPackageIndexExists pool repositoryName $ do
@@ -107,9 +104,9 @@ importFromArchive repositoryName indexDependencies indexArchiveBasePath = do
     buildContentStream
       :: PackageIndex
       -> UTCTime
-      -> Stream (Eff es) (ImportFileType, UTCTime, Maybe Text, StrictByteString)
+      -> Stream (Eff es) ImportSubject
       -> Tar.GenEntry LazyByteString Tar.TarPath linkTarget
-      -> Stream (Eff es) (ImportFileType, UTCTime, Maybe Text, StrictByteString)
+      -> Stream (Eff es) ImportSubject
     buildContentStream packageIndex time acc entry =
       let entryPath = Tar.entryPath entry
           entryTime = posixSecondsToUTCTime . fromIntegral $ Tar.entryTime entry
@@ -132,6 +129,23 @@ importFromArchive repositoryName indexDependencies indexArchiveBasePath = do
 --   do
 --     loadJSONContent path content repository
 --     >>= persistHashes
+
+packageListOrThrow
+  :: (Error ImportError :> es, Log :> es, Show e)
+  => Text
+  -> Entries e
+  -> FloraM es (Set Flora.PackageName)
+packageListOrThrow indexName entries = do
+  packages <- case buildPackageListFromArchive entries of
+    Left err -> do
+      Log.logAttention "Could not parse package index" $
+        object ["package_index_name" .= indexName, "error" .= show err]
+      Error.throwError $ MalformedPackageIndex indexName (Text.pack (show err))
+    Right packages -> pure packages
+  when (null packages) $ do
+    Log.logAttention "Package index has no entries" $ object ["package_index_name" .= indexName]
+    Error.throwError $ EmptyPackageIndex indexName
+  pure packages
 
 {-# HLINT ignore "Functor law" #-}
 buildPackageListFromArchive :: Entries e -> Either e (Set Flora.PackageName)

--- a/src/core/Flora/Domain/Import/Package/Bulk/Stream.hs
+++ b/src/core/Flora/Domain/Import/Package/Bulk/Stream.hs
@@ -3,7 +3,6 @@ module Flora.Domain.Import.Package.Bulk.Stream
   ) where
 
 import Control.Monad
-import Data.ByteString (StrictByteString)
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Vector (Vector)
@@ -12,6 +11,7 @@ import Distribution.Types.Version (Version)
 import Effectful
 import Effectful.Concurrent (Concurrent)
 import Effectful.Error.Static (Error)
+import Effectful.Error.Static qualified as Error
 import Effectful.Log (Log)
 import Effectful.Prometheus
 import Effectful.Reader.Static (Reader)
@@ -38,7 +38,7 @@ import Flora.Model.PackageIndex.Update qualified as Update
 import Flora.Model.Release.Query qualified as Query
 import Flora.Model.Release.Update qualified as Update
 import Flora.Monad
-import Flora.Monitoring (increasePackageImportCounterBy)
+import Flora.Monitoring (increaseImportFailureCounter, increasePackageImportCounterBy)
 
 importFromStream
   :: forall es
@@ -54,15 +54,15 @@ importFromStream
      )
   => PackageIndex
   -> Vector (Text, Set Flora.PackageName)
-  -> Stream (Eff es) (ImportFileType, UTCTime, Maybe Text, StrictByteString)
+  -> Stream (Eff es) ImportSubject
   -> FloraM es ()
 importFromStream packageIndex indexPackages stream = do
   env <- Reader.ask
   let workerLimit = max 1 (env.dbConfig.connections `div` 2)
       cfg = Streamly.maxThreads workerLimit . Streamly.maxBuffer workerLimit . Streamly.inspect True
-  processedPackageCount <-
+  Tally total failures <-
     finally
-      ( Streamly.fold displayCount $
+      ( Streamly.fold tally $
           Streamly.parMapM cfg (processFile packageIndex indexPackages) stream
       )
       -- We want to refresh db and update latest timestamp even if we fell
@@ -74,17 +74,27 @@ importFromStream packageIndex indexPackages stream = do
             Update.refreshDependents
             Update.updatePackageIndexByName packageIndex.repository timestamp
       )
-  displayStats processedPackageCount
-  increasePackageImportCounterBy processedPackageCount packageIndex.repository
+  unless (total `mod` progressBatchSize == 0) $ displayStats total
+  increasePackageImportCounterBy (total - failures) packageIndex.repository
+  let minimumSampleSize = 20
+      failureRateExceedsOnePercent = failures * 100 > total
+  when (total >= minimumSampleSize && failureRateExceedsOnePercent) $
+    Error.throwError $
+      TooManyImportFailures failures total
   where
-    displayCount :: SFold.Fold (Eff es) a Int
-    displayCount =
-      flip SFold.foldlM' (pure 0) $
-        \previousCount _ -> do
-          let currentCount = previousCount + 1
-              batchAmount = 100
-          when (currentCount `mod` batchAmount == 0) $ displayStats currentCount
-          pure currentCount
+    tally :: SFold.Fold (Eff es) Bool Tally
+    tally =
+      flip SFold.foldlM' (pure (Tally 0 0)) $
+        \(Tally previousTotal previousFailures) succeeded -> do
+          let total = previousTotal + 1
+              failures = previousFailures + (if succeeded then 0 else 1)
+          when (total `mod` progressBatchSize == 0) $ displayStats total
+          pure $ Tally total failures
+
+progressBatchSize :: Int
+progressBatchSize = 100
+
+data Tally = Tally !Int !Int
 
 displayStats
   :: IOE :> es
@@ -95,9 +105,9 @@ displayStats currentCount = do
 
 processFile
   :: ( Concurrent :> es
-     , Error ImportError :> es
      , IOE :> es
      , Log :> es
+     , Metrics AppMetrics :> es
      , Reader FloraEnv :> es
      , RequireCallStack
      , State (Set (Namespace, Flora.PackageName, Version)) :> es
@@ -105,13 +115,20 @@ processFile
      )
   => PackageIndex
   -> Vector (Text, Set Flora.PackageName)
-  -> (ImportFileType, UTCTime, Maybe Text, StrictByteString)
-  -> FloraM es ()
+  -> ImportSubject
+  -> FloraM es Bool
 processFile packageIndex indexPackages importSubject =
   case importSubject of
     (CabalFile path, timestamp, mUsername, content) -> Log.localData ["filepath" .= path] $ do
-      Log.logInfo_ "Importing cabal file"
-      genericPackageDescription <- parseString parseGenericPackageDescription path content
-      Log.logInfo_ "Parsed package description"
-      importOutput <- extractPackageDataFromCabal packageIndex indexPackages timestamp mUsername genericPackageDescription
-      persistImportOutput importOutput
+      result <- Error.runErrorNoCallStack @ImportError $ do
+        Log.logInfo_ "Importing cabal file"
+        genericPackageDescription <- parseString parseGenericPackageDescription path content
+        Log.logInfo_ "Parsed package description"
+        importOutput <- extractPackageDataFromCabal packageIndex indexPackages timestamp mUsername genericPackageDescription
+        persistImportOutput importOutput
+      case result of
+        Right () -> pure True
+        Left err -> do
+          Log.logAttention "Failed to import cabal file" $ object ["error" .= show err]
+          increaseImportFailureCounter packageIndex.repository (importErrorReason err)
+          pure False

--- a/src/core/Flora/Domain/Import/Types.hs
+++ b/src/core/Flora/Domain/Import/Types.hs
@@ -1,5 +1,9 @@
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
+
 module Flora.Domain.Import.Types
   ( ImportError (..)
+  , importErrorReason
+  , ImportSubject
   , Target (..)
   , Hashes (..)
   , ImportFileType (..)
@@ -10,7 +14,10 @@ module Flora.Domain.Import.Types
 import Control.Exception
 import Data.Aeson
 import Data.Aeson.KeyMap
+import Data.ByteString (StrictByteString)
 import Data.Text (Text)
+import Data.Time (UTCTime)
+import Distribution.Version (Version)
 import GHC.Generics
 import Text.Pandoc.Error
 
@@ -29,8 +36,32 @@ data ImportError
   | CouldNotFindPackageUploader Text Namespace
   | CouldNotFindPackage Namespace PackageName
   | MarkdownRenderingError PandocError
+  | NoImportableComponents Namespace PackageName Version
+  | MalformedPackageIndex Text Text
+  | EmptyPackageIndex Text
+  | TooManyImportFailures Int Int
   deriving stock (Show)
   deriving anyclass (Exception)
+
+importErrorReason :: ImportError -> Text
+importErrorReason = \case
+  InvalidPackageName{} -> "invalid-package-name"
+  NoSourceRepoFound{} -> "no-source-repo"
+  RequirementNotFound{} -> "requirement-not-found"
+  CabalFileNotFound{} -> "cabal-file-not-found"
+  CabalFileCouldNotBeParsed{} -> "cabal-parse-error"
+  CouldNotSelectNamespace{} -> "namespace-not-found"
+  CouldNotFindPackageIndexForRelease{} -> "package-index-not-found"
+  CouldNotFindPackageIndex{} -> "package-index-not-found"
+  CouldNotFindPackageUploader{} -> "package-uploader-not-found"
+  CouldNotFindPackage{} -> "package-not-found"
+  MarkdownRenderingError{} -> "markdown-rendering-error"
+  NoImportableComponents{} -> "no-importable-components"
+  MalformedPackageIndex{} -> "malformed-package-index"
+  EmptyPackageIndex{} -> "empty-package-index"
+  TooManyImportFailures{} -> "too-many-import-failures"
+
+type ImportSubject = (ImportFileType, UTCTime, Maybe Text, StrictByteString)
 
 data ReleaseJSONFile = ReleaseJSONFile
   { signed :: Signed

--- a/src/core/Flora/Environment/Env.hs
+++ b/src/core/Flora/Environment/Env.hs
@@ -44,6 +44,7 @@ data FloraEnv = FloraEnv
 
 data AppMetrics = AppMetrics
   { packageImportCounter :: P.Vector P.Label1 P.Counter
+  , packageImportFailureCounter :: P.Vector P.Label2 P.Counter
   , buildInformation :: P.Vector P.Label2 P.Gauge
   }
 

--- a/src/core/Flora/Model/Release/Query.hs
+++ b/src/core/Flora/Model/Release/Query.hs
@@ -68,8 +68,9 @@ getLatestPackageRelease pid =
   queryOne getLatestPackageReleaseQuery (Only pid)
 
 getLatestReleaseTime :: (IOE :> es, ReadDB :> es) => Maybe Text -> FloraM es (Maybe UTCTime)
-getLatestReleaseTime repo =
-  fmap fromOnly <$> maybe (queryOne_ q') (queryOne q . Only) repo
+getLatestReleaseTime repo = do
+  result :: Maybe (Only (Maybe UTCTime)) <- maybe (queryOne_ q') (queryOne q . Only) repo
+  pure $ result >>= fromOnly
   where
     q = [sql| select max(r0.uploaded_at) from releases as r0 where r0.repository = ? |]
     q' = [sql| select max(uploaded_at) from releases |]

--- a/src/core/Flora/Monitoring.hs
+++ b/src/core/Flora/Monitoring.hs
@@ -6,6 +6,7 @@ module Flora.Monitoring
   , registerMetrics
   , increaseCounterBy
   , increasePackageImportCounterBy
+  , increaseImportFailureCounter
   , setGitHash
   ) where
 
@@ -31,6 +32,13 @@ registerMetrics = do
               { metricName = "flora_imported_packages_total"
               , metricHelp = "Packages imported and their index"
               }
+  let packageImportFailureCount =
+        P.vector ("package_index", "reason") $
+          P.counter
+            P.Info
+              { metricName = "flora_import_failures_total"
+              , metricHelp = "Packages that failed to import, and why"
+              }
   let gitHashMetric =
         P.vector ("git_revision", "version") $
           P.gauge
@@ -39,8 +47,9 @@ registerMetrics = do
               , metricHelp = "Build information"
               }
   packageImportCounter <- P.register packageImportCount
+  packageImportFailureCounter <- P.register packageImportFailureCount
   gitHashText <- P.register gitHashMetric
-  pure $ AppMetrics packageImportCounter gitHashText
+  pure $ AppMetrics packageImportCounter packageImportFailureCounter gitHashText
 
 setGitHash
   :: Metrics AppMetrics :> es
@@ -70,3 +79,11 @@ increasePackageImportCounterBy
   -> Eff es ()
 increasePackageImportCounterBy value repository = do
   increaseCounterBy value repository
+
+increaseImportFailureCounter
+  :: Metrics AppMetrics :> es
+  => Text
+  -> Text
+  -> Eff es ()
+increaseImportFailureCounter repository reason = do
+  increaseLabelledCounter (.packageImportFailureCounter) (repository, reason)

--- a/test/Flora/ImportSpec.hs
+++ b/test/Flora/ImportSpec.hs
@@ -2,19 +2,29 @@ module Flora.ImportSpec where
 
 import Codec.Archive.Tar qualified as Tar
 import Codec.Compression.GZip qualified as GZip
+import Control.Monad (void)
+import Data.ByteString (StrictByteString)
+import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.Maybe (catMaybes)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Vector qualified as Vector
+import Effectful.Error.Static qualified as Error
 import Effectful.Reader.Static qualified as Reader
+import Effectful.State.Static.Shared qualified as State
 import Log.Backend.StandardOutput (withStdOutLogger)
 import RequireCallStack
+import Streamly.Data.Stream qualified as Stream
 
 import Flora.Database
 import Flora.Domain.Import.Package (chooseNamespace)
 import Flora.Domain.Import.Package.Bulk.Archive
+import Flora.Domain.Import.Package.Bulk.Stream (importFromStream)
+import Flora.Domain.Import.Types (ImportError (..), ImportFileType (..))
 import Flora.Environment.Env
 import Flora.Model.Package.Query qualified as Query
 import Flora.Model.Package.Types
@@ -33,6 +43,9 @@ spec =
     , testThis "Package list from archive" testPackageListFromArchive
     , testThis "MLabs dependencies in Cardano are correctly inserted" testNthLevelDependencies
     , testThis "Cardano dependencies are preferred in Cardano, then in Hackage" testCardanoDependencyResolution
+    , testThis "One bad cabal file among many good ones does not fail the import" testImportStreamSkipsBadFilesUnderThreshold
+    , testThis "High failure rate trips the import circuit breaker" testImportStreamTripsCircuitBreakerOverThreshold
+    , testThis "Repository with zero successful imports does not crash on NULL latest-release-time" testImportStreamAllFailuresUnderFloorDoesNotCrash
     ]
 
 testIndex :: FilePath
@@ -51,10 +64,7 @@ testImportIndex :: RequireCallStack => TestEff ()
 testImportIndex = withStdOutLogger $
   \_ -> do
     FloraEnv{pool} <- Reader.ask
-    mIndex <- withReadOnlyPool pool $ Query.getPackageIndexByName defaultRepo
-    case mIndex of
-      Nothing -> withReadWritePool pool $ Update.createPackageIndex defaultRepo defaultRepoURL defaultDescription Nothing
-      Just _ -> pure ()
+    withReadWritePool pool $ Update.upsertPackageIndex defaultRepo defaultRepoURL defaultDescription Nothing
     importFromArchive
       "test-namespace"
       Vector.empty
@@ -99,6 +109,70 @@ testNthLevelDependencies = do
         ]
     )
     dependencies
+
+resilienceGoodName :: Int -> String
+resilienceGoodName n = "resilience-good" <> show n
+
+goodCabalFile :: Int -> StrictByteString
+goodCabalFile n =
+  BS8.pack $
+    unlines
+      [ "cabal-version: 3.0"
+      , "name: " <> resilienceGoodName n
+      , "version: 1.0.0"
+      , "build-type: Simple"
+      , ""
+      , "library"
+      , "  exposed-modules: ResilienceGood"
+      , "  build-depends: base"
+      , "  default-language: Haskell2010"
+      ]
+
+badCabalFile :: StrictByteString
+badCabalFile = "this is not a valid cabal file !!!"
+
+runResilienceImport :: RequireCallStack => Text -> Int -> Int -> TestEff ()
+runResilienceImport repo goodCount badCount = do
+  FloraEnv{pool} <- Reader.ask
+  withReadWritePool pool $ Update.upsertPackageIndex repo defaultRepoURL defaultDescription Nothing
+  packageIndex <- assertJust_ =<< withReadOnlyPool pool (Query.getPackageIndexByName repo)
+  let indexPackages =
+        Vector.singleton
+          ( repo
+          , Set.fromList [PackageName (Text.pack (resilienceGoodName n)) | n <- [1 .. goodCount]]
+          )
+      epoch = posixSecondsToUTCTime 0
+      subjects =
+        [ (CabalFile (resilienceGoodName n <> ".cabal"), epoch, Nothing, goodCabalFile n)
+        | n <- [1 .. goodCount]
+        ]
+          <> replicate badCount (CabalFile "resilience-bad.cabal", epoch, Nothing, badCabalFile)
+  State.evalState mempty $
+    importFromStream packageIndex indexPackages (Stream.fromList subjects)
+
+testImportStreamSkipsBadFilesUnderThreshold :: RequireCallStack => TestEff ()
+testImportStreamSkipsBadFilesUnderThreshold = do
+  FloraEnv{pool} <- Reader.ask
+  let repo = "resilience-test"
+  runResilienceImport repo 99 1
+  void . assertJust_
+    =<< withReadOnlyPool pool (Query.getPackageByNamespaceAndName (Namespace repo) (PackageName "resilience-good1"))
+
+testImportStreamTripsCircuitBreakerOverThreshold :: RequireCallStack => TestEff ()
+testImportStreamTripsCircuitBreakerOverThreshold = do
+  result <- Error.tryError @ImportError $ runResilienceImport "resilience-test-cb" 19 1
+  case result of
+    Left (_, TooManyImportFailures failures total) -> assertEqual_ (1 :: Int, 20 :: Int) (failures, total)
+    Left (_, err) -> assertFailure $ "expected TooManyImportFailures, got " <> show err
+    Right () -> assertFailure "import unexpectedly succeeded"
+
+testImportStreamAllFailuresUnderFloorDoesNotCrash :: RequireCallStack => TestEff ()
+testImportStreamAllFailuresUnderFloorDoesNotCrash = do
+  FloraEnv{pool} <- Reader.ask
+  let repo = "resilience-test-allfail"
+  runResilienceImport repo 0 5
+  latestReleaseTime <- withReadOnlyPool pool $ Query.getLatestReleaseTime (Just repo)
+  assertEqual "no release was ever persisted for this repository" Nothing latestReleaseTime
 
 testCardanoDependencyResolution :: RequireCallStack => TestEff ()
 testCardanoDependencyResolution = do

--- a/test/Flora/TestUtils.hs
+++ b/test/Flora/TestUtils.hs
@@ -88,7 +88,7 @@ module Flora.TestUtils
   )
 where
 
-import Control.Exception (throw)
+import Control.Exception (throw, throwIO)
 import Control.Monad (void)
 import Control.Monad.Catch
 import Data.Function
@@ -229,7 +229,7 @@ runTestEff comp env = runEff $
       & Error.runErrorWith
         ( \callstack err -> do
             liftIO $ putStrLn $ prettyCallStack callstack
-            pure $ error $ show err
+            liftIO $ throwIO $ userError $ show err
         )
 
 testThis :: (HasCallStack, RequireCallStack) => String -> TestEff () -> TestEff TestTree


### PR DESCRIPTION
Previously, failure to parse a cabal file would result in an Error bubbling up and cancelling the whole tarball import. Now we are more granular in how such errors are caught and reported.

Fixes FLORA-301