### PR TITLE
Label the worker threads by queue name and payload identifier

### DIFF
--- a/app/jobs/Main.hs
+++ b/app/jobs/Main.hs
@@ -93,6 +93,7 @@ main = do
       defaultConfig <- liftIO $
         Worker.defaultBatchedWorkerConfig (connString floraEnv.config.connectionInfo) 50 1 $
           \(job :| _) callbacks -> do
+            liftIO $ labelCurrentThread (Text.unpack ("job-" <> job.queueName <> "-" <> jobTypeLabel job.payload))
             processJob workerEnv jobsEnv logger floraEnv traceRunner job
             Worker.ack callbacks job
       let instrumentedHooks =


### PR DESCRIPTION
Today when dumping the blocked threads of the jobs worker, we can see this:

```
==== flora-jobs-runner pid 6069 thread dump at 2026-07-31T11:15:14.170034746Z ====
capabilities: 12  processors: 12  threads: 77

summary:
  55      ThreadBlocked BlockedOnSTM
  12      ThreadBlocked BlockedOnForeignCall
  9       ThreadBlocked BlockedOnMVar
  1       ThreadRunning

threads:
  ThreadId 2      ThreadBlocked BlockedOnForeignCall  IOManager on cap 0
  ThreadId 3      ThreadBlocked BlockedOnForeignCall  IOManager on cap 1
  ThreadId 4      ThreadBlocked BlockedOnForeignCall  IOManager on cap 2
  ThreadId 5      ThreadBlocked BlockedOnForeignCall  IOManager on cap 3
  ThreadId 6      ThreadBlocked BlockedOnForeignCall  IOManager on cap 4
  ThreadId 7      ThreadBlocked BlockedOnForeignCall  IOManager on cap 5
  ThreadId 8      ThreadBlocked BlockedOnForeignCall  IOManager on cap 6
  ThreadId 9      ThreadBlocked BlockedOnForeignCall  IOManager on cap 7
  ThreadId 10     ThreadBlocked BlockedOnForeignCall  IOManager on cap 8
  ThreadId 11     ThreadBlocked BlockedOnForeignCall  IOManager on cap 9
  ThreadId 12     ThreadBlocked BlockedOnForeignCall  IOManager on cap 10
  ThreadId 13     ThreadBlocked BlockedOnMVar         IOManager on cap 11
  ThreadId 14     ThreadBlocked BlockedOnForeignCall  TimerManager
  ThreadId 15     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 17     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 18     ThreadBlocked BlockedOnMVar         resource-pool: collector ()
  ThreadId 20     ThreadBlocked BlockedOnMVar         resource-pool: collector ()
  ThreadId 22     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 23     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 24     ThreadBlocked BlockedOnMVar         jobs-http-server
  ThreadId 25     ThreadBlocked BlockedOnMVar         jobs-queue-metrics
  ThreadId 26     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 27     ThreadBlocked BlockedOnMVar         <unlabelled>
  ThreadId 28     ThreadBlocked BlockedOnMVar         <unlabelled>
  ThreadId 29     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 30     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 31     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 32     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 33     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 34     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 35     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 36     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 37     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 38     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 39     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 40     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 41     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 42     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 43     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 44     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 45     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 46     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 47     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 48     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 49     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 50     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 51     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 52     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 53     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 54     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 55     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 56     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 57     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 58     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 59     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 60     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 61     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 62     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 63     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 64     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 65     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 66     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 67     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 68     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 69     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 70     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 71     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 72     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 73     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 74     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 75     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 76     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 77     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 78     ThreadBlocked BlockedOnSTM          <unlabelled>
  ThreadId 79     ThreadBlocked BlockedOnMVar         <unlabelled>
  ThreadId 80     ThreadBlocked BlockedOnMVar         <unlabelled>
  ThreadId 2001   ThreadRunning                       <unlabelled>
```

Which is a lot of unlabelled threads. Let's see if we can fix that and see which jobs are blocked on STM.