### PR TITLE
Configuration templates ADR

### DIFF
--- a/architecture/0002-local-configuration-templates.md
+++ b/architecture/0002-local-configuration-templates.md
@@ -1,0 +1,39 @@
+# 2. Local configuration templates
+
+Date: 2026-08-11
+
+## Status
+
+Proposed
+
+## Context
+
+With various ways of running the various executables (local, docker-compose),
+it's important to adjust the configuration files to have the adequate values
+
+## Decision
+
+We will have a script (`scripts/generate-configuration.sh`) that will receive
+the desired setup will select the appropriate configuration template and put it
+in a well-known place.
+
+So far there are three configurations:
+
+* docker (`-d|--docker`)
+* local (`-l|--local`)
+* ci (`-c|-ci`)
+
+As such, `environment.*.kdl` files will be re-designed. Executables will
+hardcode which files they need for normal operations and running tests.
+
+* `flora.kdl`
+* `flora_test.kdl`
+
+* `jobs_runner.kdl`
+* `jobs_runner_test.kdl`
+
+## Consequences
+
+Since the expected files will be picked according to the developer's platform,
+they will not be tracked by git. Therefore, the executables will have to guide
+the user to running the generation script if they don't find the files on disk.


### PR DESCRIPTION
View at: https://github.com/flora-pm/flora-server/blob/new-configuration-templates-system/architecture/0002-local-configuration-templates.md

## Configuration templates ADR

I'd like to tackle some inherent complexity in our configuration, because so far we have various environments (local, docker, CI) that need different values, but we also want to have _well-known_ locations for configuration files, so they don't need to be passed manually to the executables.